### PR TITLE
Add ur5 arm with moveit support

### DIFF
--- a/Assets/ur5Moveit.prefab
+++ b/Assets/ur5Moveit.prefab
@@ -1,0 +1,2321 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "urMoveit",
+        "Components": {
+            "EditorDisabledCompositionComponent": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 8731335431572752431
+            },
+            "EditorEntityIconComponent": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 16612825841320859745
+            },
+            "EditorEntitySortComponent": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 3752664466351333644,
+                "Child Entity Order": [
+                    "Entity_[694692034199]"
+                ]
+            },
+            "EditorInspectorComponent": {
+                "$type": "EditorInspectorComponent",
+                "Id": 10393986046246645228
+            },
+            "EditorLockComponent": {
+                "$type": "EditorLockComponent",
+                "Id": 16738429624386434745
+            },
+            "EditorOnlyEntityComponent": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 16567789309435221192
+            },
+            "EditorPendingCompositionComponent": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 7461996620812806601
+            },
+            "EditorPrefabComponent": {
+                "$type": "EditorPrefabComponent",
+                "Id": 7728380282073828228
+            },
+            "EditorVisibilityComponent": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 5594778468236540968
+            },
+            "TransformComponent": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 17264914959533092967,
+                "Parent Entity": ""
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[617382622871]": {
+            "Id": "Entity_[617382622871]",
+            "Name": "forearm_link",
+            "Components": {
+                "EditorArticulationLinkComponent": {
+                    "$type": "EditorArticulationLinkComponent",
+                    "Id": 5487282064059159540,
+                    "ArticulationConfiguration": {
+                        "entityId": "",
+                        "Articulation Joint Type": 1,
+                        "Local Rotation": [
+                            0.0,
+                            -90.0,
+                            0.0
+                        ],
+                        "Angular Limit Negative": 180.0,
+                        "Angular Limit Positive": -180.0,
+                        "Motor configuration": {
+                            "UseMotor": true,
+                            "ForceLimit": 1000.0,
+                            "Stiffness": 2000.0,
+                            "Damping": 300.0
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10398996226318864671,
+                    "DisabledComponents": {
+                        "EditorRigidBodyComponent": {
+                            "$type": "EditorRigidBodyComponent",
+                            "Id": 2516350535976444155,
+                            "Configuration": {
+                                "entityId": "",
+                                "Compute Mass": false,
+                                "Mass": 2.2750000953674316,
+                                "Compute COM": false,
+                                "Centre of mass offset": [
+                                    -0.19612500071525574,
+                                    0.0,
+                                    0.016499999910593033
+                                ],
+                                "Compute inertia": false,
+                                "Inertia tensor": [
+                                    0.03121679089963436,
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    0.03121679089963436,
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    0.004095000214874744
+                                ]
+                            },
+                            "PhysXSpecificConfiguration": {
+                                "SolverPositionIterations": 40,
+                                "SolverVelocityIterations": 10
+                            }
+                        }
+                    }
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 8190228862534546402
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 1868078455822786953,
+                    "Child Entity Order": [
+                        "Entity_[690397066903]",
+                        "Entity_[656037328535]"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 204298559682621574
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 11623586191560432220
+                },
+                "EditorMeshColliderComponent": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 3012880230076608879,
+                    "ColliderConfiguration": {
+                        "Position": [
+                            0.0,
+                            0.0,
+                            0.016499999910593033
+                        ],
+                        "Rotation": [
+                            0.5,
+                            -0.5,
+                            -0.5,
+                            0.5
+                        ],
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "DefaultMaterial"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "PhysicsAsset": {
+                            "Asset": {
+                                "assetId": {
+                                    "guid": "{91DF02AB-4A5A-534E-B9FE-63297EB983CA}",
+                                    "subId": 1488848390
+                                },
+                                "assetHint": "assets/urdfimporter/783534404_ur.urdf/forearm.pxmesh"
+                            },
+                            "Configuration": {
+                                "PhysicsAsset": {
+                                    "assetId": {
+                                        "guid": "{91DF02AB-4A5A-534E-B9FE-63297EB983CA}",
+                                        "subId": 1488848390
+                                    },
+                                    "loadBehavior": "QueueLoad",
+                                    "assetHint": "assets/urdfimporter/783534404_ur.urdf/forearm.pxmesh"
+                                },
+                                "UseMaterialsFromAsset": false
+                            }
+                        }
+                    }
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5864465957870259376
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7487096221790961974,
+                    "PendingComponents": {
+                        "EditorHingeJointComponent": {
+                            "$type": "EditorHingeJointComponent",
+                            "Id": 15804288157601571380,
+                            "Configuration": {
+                                "Local Rotation": [
+                                    0.0,
+                                    -89.99999237060547,
+                                    0.0
+                                ],
+                                "Parent Entity": "Entity_[625972557463]",
+                                "Child Entity": "Entity_[617382622871]"
+                            },
+                            "Angular Limit": {
+                                "Positive Limit": 180.0,
+                                "Negative Limit": -180.0
+                            }
+                        }
+                    }
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 6972841326910009327
+                },
+                "ROS2FrameComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 1598407247910721613,
+                    "m_template": {
+                        "$type": "ROS2FrameComponent",
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "forearm_link",
+                        "Joint Name": "elbow_joint",
+                        "Publish Transform": false
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 17085465699576292114,
+                    "Parent Entity": "Entity_[625972557463]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.42500001192092896,
+                            0.0,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.000006830188794992864,
+                            -9.039679602072037e-29,
+                            -1.5166065725475662e-21
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[621677590167]": {
+            "Id": "Entity_[621677590167]",
+            "Name": "upper_arm_link_visual",
+            "Components": {
+                "AZ::Render::EditorMeshComponent": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 2371594324366327478,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{7F63A70F-C620-52D5-B601-D7BE161B8273}",
+                                    "subId": 270772955
+                                },
+                                "assetHint": "assets/urdfimporter/783534404_ur.urdf/upperarm.azmodel"
+                            }
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9386229655167429798
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 15586867683959172372
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 1854306022434033683
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 8090257565750491237
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 9823336549455137192
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 17608697224599962675
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 4865147845890142736
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 6849516534498500587
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5069271604893115754,
+                    "Parent Entity": "Entity_[625972557463]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.0,
+                            0.0,
+                            0.1358499974012375
+                        ],
+                        "Rotate": [
+                            90.0,
+                            -90.0,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[625972557463]": {
+            "Id": "Entity_[625972557463]",
+            "Name": "upper_arm_link",
+            "Components": {
+                "EditorArticulationLinkComponent": {
+                    "$type": "EditorArticulationLinkComponent",
+                    "Id": 18058751888823389455,
+                    "ArticulationConfiguration": {
+                        "entityId": "",
+                        "Articulation Joint Type": 1,
+                        "Local Rotation": [
+                            0.0,
+                            -90.0,
+                            0.0
+                        ],
+                        "Angular Limit Negative": 360.0,
+                        "Angular Limit Positive": -360.0,
+                        "Motor configuration": {
+                            "UseMotor": true,
+                            "ForceLimit": 1000.0,
+                            "Stiffness": 2000.0,
+                            "Damping": 300.0
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 15721472470196073362,
+                    "DisabledComponents": {
+                        "EditorRigidBodyComponent": {
+                            "$type": "EditorRigidBodyComponent",
+                            "Id": 13411689545511788138,
+                            "Configuration": {
+                                "entityId": "",
+                                "Compute Mass": false,
+                                "Mass": 8.392999649047852,
+                                "Compute COM": false,
+                                "Centre of mass offset": [
+                                    -0.21250000596046448,
+                                    0.0,
+                                    0.13600000739097595
+                                ],
+                                "Compute inertia": false,
+                                "Inertia tensor": [
+                                    0.13388578593730927,
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    0.13388578593730927,
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    0.01510739978402853
+                                ]
+                            },
+                            "PhysXSpecificConfiguration": {
+                                "SolverPositionIterations": 40,
+                                "SolverVelocityIterations": 10
+                            }
+                        }
+                    }
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 15609529035781087829
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 1027454743946023850,
+                    "Child Entity Order": [
+                        "Entity_[621677590167]",
+                        "Entity_[617382622871]"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 12585704030099341764
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 16227665108153586142
+                },
+                "EditorMeshColliderComponent": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 12892795265270443520,
+                    "ColliderConfiguration": {
+                        "Position": [
+                            0.0,
+                            0.0,
+                            0.1358499974012375
+                        ],
+                        "Rotation": [
+                            0.5,
+                            -0.5,
+                            -0.5,
+                            0.5
+                        ],
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "DefaultMaterial"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "PhysicsAsset": {
+                            "Asset": {
+                                "assetId": {
+                                    "guid": "{977CDA7F-B9BC-546B-9DED-4C8A07B9255F}",
+                                    "subId": 3662157329
+                                },
+                                "assetHint": "assets/urdfimporter/783534404_ur.urdf/upperarm.pxmesh"
+                            },
+                            "Configuration": {
+                                "PhysicsAsset": {
+                                    "assetId": {
+                                        "guid": "{977CDA7F-B9BC-546B-9DED-4C8A07B9255F}",
+                                        "subId": 3662157329
+                                    },
+                                    "loadBehavior": "QueueLoad",
+                                    "assetHint": "assets/urdfimporter/783534404_ur.urdf/upperarm.pxmesh"
+                                },
+                                "UseMaterialsFromAsset": false
+                            }
+                        }
+                    }
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 9660889048282513150
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14425183701703761385,
+                    "PendingComponents": {
+                        "EditorHingeJointComponent": {
+                            "$type": "EditorHingeJointComponent",
+                            "Id": 3987400519655772359,
+                            "Configuration": {
+                                "Local Rotation": [
+                                    0.0,
+                                    -89.99999237060547,
+                                    0.0
+                                ],
+                                "Parent Entity": "Entity_[698987001495]",
+                                "Child Entity": "Entity_[625972557463]"
+                            },
+                            "Angular Limit": {
+                                "Positive Limit": 360.0,
+                                "Negative Limit": -360.0
+                            }
+                        }
+                    }
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 1717663267053625784
+                },
+                "ROS2FrameComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 4773712240584269181,
+                    "m_template": {
+                        "$type": "ROS2FrameComponent",
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "upper_arm_link",
+                        "Joint Name": "shoulder_lift_joint",
+                        "Publish Transform": false
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6694108772245886530,
+                    "Parent Entity": "Entity_[698987001495]",
+                    "Transform Data": {
+                        "Rotate": [
+                            89.99998474121094,
+                            -7.0167078561561656e-15,
+                            3.7915164313689154e-22
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[630267524759]": {
+            "Id": "Entity_[630267524759]",
+            "Name": "flange",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 5487668032515463895
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 10657555192373799839
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2128839892510514014,
+                    "Child Entity Order": [
+                        "Entity_[634562492055]"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 12986072092989922372
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 324782338854942893
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4219138306619743263
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14307318628094693385,
+                    "PendingComponents": {
+                        "EditorFixedJointComponent": {
+                            "$type": "EditorFixedJointComponent",
+                            "Id": 2661907883375729967,
+                            "Configuration": {
+                                "Parent Entity": "",
+                                "Child Entity": ""
+                            }
+                        }
+                    }
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9262917567651941944
+                },
+                "ROS2FrameComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 11452813133349082093,
+                    "m_template": {
+                        "$type": "ROS2FrameComponent",
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "flange",
+                        "Joint Name": "wrist_3-flange",
+                        "Publish Transform": false
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6396529541356482957,
+                    "Parent Entity": "Entity_[703281968791]",
+                    "Transform Data": {
+                        "Rotate": [
+                            -89.9999771118164,
+                            0.000001707547198748216,
+                            -90.00000762939453
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[634562492055]": {
+            "Id": "Entity_[634562492055]",
+            "Name": "tool0",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13413178575742643823
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 11255469048557461146
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 14258789409936656255
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 80174993496017673
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 11612827455517078107
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2344443374280246020
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17171151966305139016,
+                    "PendingComponents": {
+                        "EditorFixedJointComponent": {
+                            "$type": "EditorFixedJointComponent",
+                            "Id": 7046635627295538536,
+                            "Configuration": {
+                                "Parent Entity": "",
+                                "Child Entity": ""
+                            }
+                        }
+                    }
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 8289410352839384870
+                },
+                "ROS2FrameComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 9068964610393013544,
+                    "m_template": {
+                        "$type": "ROS2FrameComponent",
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "tool0",
+                        "Joint Name": "flange-tool0",
+                        "Publish Transform": false
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9595406432288590372,
+                    "Parent Entity": "Entity_[630267524759]",
+                    "Transform Data": {
+                        "Rotate": [
+                            90.0,
+                            89.99996185302734,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[638857459351]": {
+            "Id": "Entity_[638857459351]",
+            "Name": "base_link_inertia_visual",
+            "Components": {
+                "AZ::Render::EditorMeshComponent": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 3160578405473985669,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{501BBAEE-663A-5A82-B1FB-2FBF8F3F7110}",
+                                    "subId": 280297057
+                                },
+                                "assetHint": "assets/urdfimporter/783534404_ur.urdf/base.azmodel"
+                            }
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 3332433060282292592
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 9688661122154598627
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16752754898612745570
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 4081645116466393
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 10924230022216563448
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 12010511056632313253
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14114652638883248470
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 3402403668426314660
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 2144851322405332082,
+                    "Parent Entity": "Entity_[651742361239]",
+                    "Transform Data": {
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[643152426647]": {
+            "Id": "Entity_[643152426647]",
+            "Name": "wrist_1_link_visual",
+            "Components": {
+                "AZ::Render::EditorMeshComponent": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 5435841460942642258,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{0AADB8B5-BDAA-5845-985F-172184352826}",
+                                    "subId": 283376957
+                                },
+                                "assetHint": "assets/urdfimporter/783534404_ur.urdf/wrist1.azmodel"
+                            }
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 12502295652067234470
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 12567171959276140635
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 13909866522374758448
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 8806087152263638337
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 13556774301632968640
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2357044949983239856
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 3400093061036791327
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 18269154857932012113
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 2150584639897984520,
+                    "Parent Entity": "Entity_[656037328535]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.0,
+                            0.0,
+                            -0.09300000220537186
+                        ],
+                        "Rotate": [
+                            89.99999237060547,
+                            0.0,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[647447393943]": {
+            "Id": "Entity_[647447393943]",
+            "Name": "wrist_2_link_visual",
+            "Components": {
+                "AZ::Render::EditorMeshComponent": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 11098521529429125383,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{034FE6AD-C9B4-5FD0-8BA6-9D7A2BBF5719}",
+                                    "subId": 283815047
+                                },
+                                "assetHint": "assets/urdfimporter/783534404_ur.urdf/wrist2.azmodel"
+                            }
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16872778830819676783
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 11423037910936679083
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 495537097350871562
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 12752307428971400844
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2412323094693626842
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 15019513350538767434
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 345986957434801607
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 6248196006010180966
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 7865275478626892876,
+                    "Parent Entity": "Entity_[673217197719]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.0,
+                            0.0,
+                            -0.0949999988079071
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[651742361239]": {
+            "Id": "Entity_[651742361239]",
+            "Name": "base_link_inertia",
+            "Components": {
+                "EditorArticulationLinkComponent": {
+                    "$type": "EditorArticulationLinkComponent",
+                    "Id": 18004175037883671043,
+                    "ArticulationConfiguration": {
+                        "entityId": ""
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13678366325942524724,
+                    "DisabledComponents": {
+                        "EditorRigidBodyComponent": {
+                            "$type": "EditorRigidBodyComponent",
+                            "Id": 11316019482129754262,
+                            "Configuration": {
+                                "entityId": "",
+                                "Compute Mass": false,
+                                "Mass": 4.0,
+                                "Compute COM": false,
+                                "Compute inertia": false,
+                                "Inertia tensor": [
+                                    0.004433331545442343,
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    0.004433331545442343,
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    0.007200000341981649
+                                ]
+                            },
+                            "PhysXSpecificConfiguration": {
+                                "SolverPositionIterations": 40,
+                                "SolverVelocityIterations": 10
+                            }
+                        }
+                    }
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16406500841097867785
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 17240616251983536940,
+                    "Child Entity Order": [
+                        "Entity_[638857459351]",
+                        "Entity_[698987001495]"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 45078894716668374
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 8166298529451985119
+                },
+                "EditorMeshColliderComponent": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 13161828885770491237,
+                    "ColliderConfiguration": {
+                        "Rotation": [
+                            0.0,
+                            0.0,
+                            1.0,
+                            6.123234262925839e-17
+                        ],
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "DefaultMaterial"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "PhysicsAsset": {
+                            "Asset": {
+                                "assetId": {
+                                    "guid": "{785530F6-38A6-51AF-8C2A-8F6FA0771984}",
+                                    "subId": 2491934069
+                                },
+                                "assetHint": "assets/urdfimporter/783534404_ur.urdf/base.pxmesh"
+                            },
+                            "Configuration": {
+                                "PhysicsAsset": {
+                                    "assetId": {
+                                        "guid": "{785530F6-38A6-51AF-8C2A-8F6FA0771984}",
+                                        "subId": 2491934069
+                                    },
+                                    "loadBehavior": "QueueLoad",
+                                    "assetHint": "assets/urdfimporter/783534404_ur.urdf/base.pxmesh"
+                                },
+                                "UseMaterialsFromAsset": false
+                            }
+                        }
+                    }
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1033332258524760046
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 13046724823623780661,
+                    "PendingComponents": {
+                        "EditorFixedJointComponent": {
+                            "$type": "EditorFixedJointComponent",
+                            "Id": 2942888710629582036,
+                            "Configuration": {
+                                "Parent Entity": "Entity_[664627263127]",
+                                "Child Entity": "Entity_[651742361239]"
+                            }
+                        }
+                    }
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 494700599786390215
+                },
+                "ROS2FrameComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 710689454373378545,
+                    "m_template": {
+                        "$type": "ROS2FrameComponent",
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "base_link_inertia",
+                        "Joint Name": "base_link-base_link_inertia",
+                        "Publish Transform": false
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 16967659122272607157,
+                    "Parent Entity": "Entity_[664627263127]",
+                    "Transform Data": {
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[656037328535]": {
+            "Id": "Entity_[656037328535]",
+            "Name": "wrist_1_link",
+            "Components": {
+                "EditorArticulationLinkComponent": {
+                    "$type": "EditorArticulationLinkComponent",
+                    "Id": 6603734076359607423,
+                    "ArticulationConfiguration": {
+                        "entityId": "",
+                        "Articulation Joint Type": 1,
+                        "Local Rotation": [
+                            0.0,
+                            -90.0,
+                            0.0
+                        ],
+                        "Angular Limit Negative": 360.0,
+                        "Angular Limit Positive": -360.0,
+                        "Motor configuration": {
+                            "UseMotor": true,
+                            "ForceLimit": 1000.0,
+                            "Stiffness": 2000.0,
+                            "Damping": 300.0
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 6283366667922547963,
+                    "DisabledComponents": {
+                        "EditorRigidBodyComponent": {
+                            "$type": "EditorRigidBodyComponent",
+                            "Id": 9083091634387490518,
+                            "Configuration": {
+                                "entityId": "",
+                                "Compute Mass": false,
+                                "Mass": 1.218999981880188,
+                                "Compute COM": false,
+                                "Compute inertia": false,
+                                "Inertia tensor": [
+                                    0.0020138886757194996,
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    0.0020138886757194996,
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    0.0021941999439150095
+                                ]
+                            },
+                            "PhysXSpecificConfiguration": {
+                                "SolverPositionIterations": 40,
+                                "SolverVelocityIterations": 10
+                            }
+                        }
+                    }
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 13426584124442234573
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 13667070041296652271,
+                    "Child Entity Order": [
+                        "Entity_[643152426647]",
+                        "Entity_[673217197719]"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 15963514784644279854
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14032049497897982494
+                },
+                "EditorMeshColliderComponent": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 17962113835867845871,
+                    "ColliderConfiguration": {
+                        "Position": [
+                            0.0,
+                            0.0,
+                            -0.09300000220537186
+                        ],
+                        "Rotation": [
+                            0.7071067690849304,
+                            0.0,
+                            0.0,
+                            0.7071067690849304
+                        ],
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "DefaultMaterial"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "PhysicsAsset": {
+                            "Asset": {
+                                "assetId": {
+                                    "guid": "{BAAD9718-A664-5BEC-92B8-8B391C0C4DAD}",
+                                    "subId": 2541752930
+                                },
+                                "assetHint": "assets/urdfimporter/783534404_ur.urdf/wrist1.pxmesh"
+                            },
+                            "Configuration": {
+                                "PhysicsAsset": {
+                                    "assetId": {
+                                        "guid": "{BAAD9718-A664-5BEC-92B8-8B391C0C4DAD}",
+                                        "subId": 2541752930
+                                    },
+                                    "loadBehavior": "QueueLoad",
+                                    "assetHint": "assets/urdfimporter/783534404_ur.urdf/wrist1.pxmesh"
+                                },
+                                "UseMaterialsFromAsset": false
+                            }
+                        }
+                    }
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4376365511047474256
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 4974049491368840350,
+                    "PendingComponents": {
+                        "EditorHingeJointComponent": {
+                            "$type": "EditorHingeJointComponent",
+                            "Id": 15082905903567508890,
+                            "Configuration": {
+                                "Local Rotation": [
+                                    0.0,
+                                    -89.99999237060547,
+                                    0.0
+                                ],
+                                "Parent Entity": "Entity_[617382622871]",
+                                "Child Entity": "Entity_[656037328535]"
+                            },
+                            "Angular Limit": {
+                                "Positive Limit": 360.0,
+                                "Negative Limit": -360.0
+                            }
+                        }
+                    }
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 6605297830136240376
+                },
+                "ROS2FrameComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 16405482811185229955,
+                    "m_template": {
+                        "$type": "ROS2FrameComponent",
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "wrist_1_link",
+                        "Joint Name": "wrist_1_joint",
+                        "Publish Transform": false
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 2195527968709481362,
+                    "Parent Entity": "Entity_[617382622871]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.3922499418258667,
+                            -2.2351741790771484e-8,
+                            0.1091499924659729
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[660332295831]": {
+            "Id": "Entity_[660332295831]",
+            "Name": "wrist_3_link_visual",
+            "Components": {
+                "AZ::Render::EditorMeshComponent": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 14460665036110572071,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{72B9A64F-89CC-5E4B-A1C7-F4B4BEFD932A}",
+                                    "subId": 284007441
+                                },
+                                "assetHint": "assets/urdfimporter/783534404_ur.urdf/wrist3.azmodel"
+                            }
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 11949808796179772996
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 4035546638758015383
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 15362935525354752564
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 3840261792979133191
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 11554521867020127350
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4530158562668287905
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11788942428252157186
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 670285659988210878
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5377617498098703144,
+                    "Parent Entity": "Entity_[703281968791]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.0,
+                            0.0,
+                            -0.08179999887943268
+                        ],
+                        "Rotate": [
+                            89.99999237060547,
+                            0.0,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[664627263127]": {
+            "Id": "Entity_[664627263127]",
+            "Name": "base_link",
+            "Components": {
+                "EditorArticulationLinkComponent": {
+                    "$type": "EditorArticulationLinkComponent",
+                    "Id": 4422926897063736124,
+                    "ArticulationConfiguration": {
+                        "entityId": "",
+                        "Fixed Base": true
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 14254051845699478482
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 8878520421989388632
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 8797251851126414648,
+                    "Child Entity Order": [
+                        "Entity_[651742361239]",
+                        "Entity_[668922230423]"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13988655352961562201
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 10763432535897720747
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 7880666295085040262
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 18098854983186689422,
+                    "PendingComponents": {
+                        "EditorFixedJointComponent": {
+                            "$type": "EditorFixedJointComponent",
+                            "Id": 2540807411163674559,
+                            "Configuration": {
+                                "Parent Entity": "",
+                                "Child Entity": ""
+                            }
+                        }
+                    }
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 7681322933007099903
+                },
+                "JointsArticulationControllerComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 10613034953263461176,
+                    "m_template": {
+                        "$type": "JointsArticulationControllerComponent"
+                    }
+                },
+                "JointsManipulationEditorComponent": {
+                    "$type": "JointsManipulationEditorComponent",
+                    "Id": 11570448542158011578,
+                    "JointStatePublisherConfiguration": {
+                        "Topic": {
+                            "QoS": {
+                                "Reliability": 1
+                            }
+                        }
+                    },
+                    "Initial positions": {
+                        "elbow_joint": -0.5,
+                        "shoulder_lift_joint": -1.5700000524520874,
+                        "shoulder_pan_joint": {},
+                        "wrist_1_joint": {},
+                        "wrist_2_joint": {},
+                        "wrist_3_joint": {}
+                    }
+                },
+                "JointsTrajectoryComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 14232996109849348123,
+                    "m_template": {
+                        "$type": "JointsTrajectoryComponent",
+                        "Action name": "joint_trajectory_controller/follow_joint_trajectory"
+                    }
+                },
+                "ROS2FrameComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 9570519104337436796,
+                    "m_template": {
+                        "$type": "ROS2FrameComponent",
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "base_link",
+                        "Joint Name": "base_joint"
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 14267296153299729953,
+                    "Parent Entity": "Entity_[681807132311]"
+                }
+            }
+        },
+        "Entity_[668922230423]": {
+            "Id": "Entity_[668922230423]",
+            "Name": "base",
+            "Components": {
+                "EditorArticulationLinkComponent": {
+                    "$type": "EditorArticulationLinkComponent",
+                    "Id": 176615949713617667,
+                    "ArticulationConfiguration": {
+                        "entityId": ""
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 14051053292040405881
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 13493396853904625509
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 13417734704769742812
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 5260637340715767945
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 1266982641498145683
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 6909065964025968662
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 12295804609010388912,
+                    "PendingComponents": {
+                        "EditorFixedJointComponent": {
+                            "$type": "EditorFixedJointComponent",
+                            "Id": 18274029838859631499,
+                            "Configuration": {
+                                "Parent Entity": "",
+                                "Child Entity": ""
+                            }
+                        }
+                    }
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4268841553206194579
+                },
+                "ROS2FrameComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 17375545524784855690,
+                    "m_template": {
+                        "$type": "ROS2FrameComponent",
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "base",
+                        "Joint Name": "base_link-base_fixed_joint",
+                        "Publish Transform": false
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 2778748892599747362,
+                    "Parent Entity": "Entity_[664627263127]",
+                    "Transform Data": {
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[673217197719]": {
+            "Id": "Entity_[673217197719]",
+            "Name": "wrist_2_link",
+            "Components": {
+                "EditorArticulationLinkComponent": {
+                    "$type": "EditorArticulationLinkComponent",
+                    "Id": 18310815693205975203,
+                    "ArticulationConfiguration": {
+                        "entityId": "",
+                        "Articulation Joint Type": 1,
+                        "Local Rotation": [
+                            0.0,
+                            -90.0,
+                            0.0
+                        ],
+                        "Angular Limit Negative": 360.0,
+                        "Angular Limit Positive": -360.0,
+                        "Motor configuration": {
+                            "UseMotor": true,
+                            "ForceLimit": 1000.0,
+                            "Stiffness": 2000.0,
+                            "Damping": 300.0
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17617519167387097473,
+                    "DisabledComponents": {
+                        "EditorRigidBodyComponent": {
+                            "$type": "EditorRigidBodyComponent",
+                            "Id": 2487664085652031084,
+                            "Configuration": {
+                                "entityId": "",
+                                "Compute Mass": false,
+                                "Mass": 1.218999981880188,
+                                "Compute COM": false,
+                                "Compute inertia": false,
+                                "Inertia tensor": [
+                                    0.0018310388550162315,
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    0.0018310388550162315,
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    0.0021941999439150095
+                                ]
+                            },
+                            "PhysXSpecificConfiguration": {
+                                "SolverPositionIterations": 40,
+                                "SolverVelocityIterations": 10
+                            }
+                        }
+                    }
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 15508321476371347544
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2299863204117196779,
+                    "Child Entity Order": [
+                        "Entity_[647447393943]",
+                        "Entity_[703281968791]"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 1245058919933504948
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 13913103442222746550
+                },
+                "EditorMeshColliderComponent": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 10681730984554024425,
+                    "ColliderConfiguration": {
+                        "Position": [
+                            0.0,
+                            0.0,
+                            -0.0949999988079071
+                        ],
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "DefaultMaterial"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "PhysicsAsset": {
+                            "Asset": {
+                                "assetId": {
+                                    "guid": "{71DF6B98-F6FB-5401-B72A-22D98F6CEAD5}",
+                                    "subId": 1158927482
+                                },
+                                "assetHint": "assets/urdfimporter/783534404_ur.urdf/wrist2.pxmesh"
+                            },
+                            "Configuration": {
+                                "PhysicsAsset": {
+                                    "assetId": {
+                                        "guid": "{71DF6B98-F6FB-5401-B72A-22D98F6CEAD5}",
+                                        "subId": 1158927482
+                                    },
+                                    "loadBehavior": "QueueLoad",
+                                    "assetHint": "assets/urdfimporter/783534404_ur.urdf/wrist2.pxmesh"
+                                },
+                                "UseMaterialsFromAsset": false
+                            }
+                        }
+                    }
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 7211263665978666777
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2495576720337268932,
+                    "PendingComponents": {
+                        "EditorHingeJointComponent": {
+                            "$type": "EditorHingeJointComponent",
+                            "Id": 4228821168727166008,
+                            "Configuration": {
+                                "Local Rotation": [
+                                    0.0,
+                                    -89.99999237060547,
+                                    0.0
+                                ],
+                                "Parent Entity": "Entity_[656037328535]",
+                                "Child Entity": "Entity_[673217197719]"
+                            },
+                            "Angular Limit": {
+                                "Positive Limit": 360.0,
+                                "Negative Limit": -360.0
+                            }
+                        }
+                    }
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 10523129334332039809
+                },
+                "ROS2FrameComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 592265520795240687,
+                    "m_template": {
+                        "$type": "ROS2FrameComponent",
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "wrist_2_link",
+                        "Joint Name": "wrist_2_joint",
+                        "Publish Transform": false
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 16780211405266599001,
+                    "Parent Entity": "Entity_[656037328535]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.0,
+                            -0.09465000033378601,
+                            -1.4901161193847656e-8
+                        ],
+                        "Rotate": [
+                            90.00000762939453,
+                            -1.5166065725475662e-21,
+                            -7.0167078561561656e-15
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[677512165015]": {
+            "Id": "Entity_[677512165015]",
+            "Name": "ft_frame",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 12086206113249903643
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 10415867052603094894
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 15121582150797679334
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11323502983263890553
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14684878311773828007
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 630863469334091193
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 3768930271661577407,
+                    "PendingComponents": {
+                        "EditorFixedJointComponent": {
+                            "$type": "EditorFixedJointComponent",
+                            "Id": 8265112374632981275,
+                            "Configuration": {
+                                "Parent Entity": "",
+                                "Child Entity": ""
+                            }
+                        }
+                    }
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 6406929912495202224
+                },
+                "ROS2FrameComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 17066634957970331869,
+                    "m_template": {
+                        "$type": "ROS2FrameComponent",
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "ft_frame",
+                        "Joint Name": "wrist_3_link-ft_frame",
+                        "Publish Transform": false
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10362111338004628344,
+                    "Parent Entity": "Entity_[703281968791]",
+                    "Transform Data": {
+                        "Rotate": [
+                            -179.99996948242188,
+                            -6.392019448087837e-29,
+                            -3.1960067147783805e-29
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[681807132311]": {
+            "Id": "Entity_[681807132311]",
+            "Name": "world",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17758815968857029180,
+                    "DisabledComponents": {
+                        "ROS2RobotControlComponent": {
+                            "$type": "GenericComponentWrapper",
+                            "Id": 5958796147330969134,
+                            "m_template": {
+                                "$type": "ROS2RobotControlComponent",
+                                "SubscriberConfiguration": {
+                                    "Topic": "cmd_vel"
+                                }
+                            }
+                        }
+                    }
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3103153820240095749
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16883111640110723514,
+                    "Child Entity Order": [
+                        "Entity_[664627263127]"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17412389210624330589
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 12591191088475009733
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 15546394054832892389
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 1541658404030856660
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13412679523387291706
+                },
+                "ROS2FrameComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 16687608679585982249,
+                    "m_template": {
+                        "$type": "ROS2FrameComponent",
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "world"
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15170193674491297571,
+                    "Parent Entity": "Entity_[694692034199]"
+                }
+            }
+        },
+        "Entity_[686102099607]": {
+            "Id": "Entity_[686102099607]",
+            "Name": "shoulder_link_visual",
+            "Components": {
+                "AZ::Render::EditorMeshComponent": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 15196015856070888726,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{30D64B4A-A307-5DE9-B53C-BFB80F1CD37C}",
+                                    "subId": 278609181
+                                },
+                                "assetHint": "assets/urdfimporter/783534404_ur.urdf/shoulder.azmodel"
+                            }
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 260405586597077418
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6006525291165616807
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9590072363551886360
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 6294473200560498155
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14627714239028699360
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 15400419738840705448
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11606562678003793631
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 12144823767700703445
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9497023756474894875,
+                    "Parent Entity": "Entity_[698987001495]",
+                    "Transform Data": {
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[690397066903]": {
+            "Id": "Entity_[690397066903]",
+            "Name": "forearm_link_visual",
+            "Components": {
+                "AZ::Render::EditorMeshComponent": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 9018726767728602351,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{61798F7A-4504-5FB3-BC48-10BC2D2A0058}",
+                                    "subId": 274532406
+                                },
+                                "assetHint": "assets/urdfimporter/783534404_ur.urdf/forearm.azmodel"
+                            }
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13606003545171020777
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 7764389262481001945
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 15598833243314752539
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 15474697857480499290
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2357668015215086102
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4613830291205216886
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 1552784901357575044
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 2494889844806244165
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10453551656793666449,
+                    "Parent Entity": "Entity_[617382622871]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.0,
+                            0.0,
+                            0.016499999910593033
+                        ],
+                        "Rotate": [
+                            90.0,
+                            -90.0,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[694692034199]": {
+            "Id": "Entity_[694692034199]",
+            "Name": "urMoveit",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13401167008807306049
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 10912266591270684797
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 1928577071263824691,
+                    "Child Entity Order": [
+                        "Entity_[681807132311]"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 256821982620115944,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 10202992886973601014
+                        }
+                    ]
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 18195379284223028734
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 9977448194352435575
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 9083105234093888756
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 14691164378096084501
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10202992886973601014,
+                    "Parent Entity": "ContainerEntity"
+                }
+            }
+        },
+        "Entity_[698987001495]": {
+            "Id": "Entity_[698987001495]",
+            "Name": "shoulder_link",
+            "Components": {
+                "EditorArticulationLinkComponent": {
+                    "$type": "EditorArticulationLinkComponent",
+                    "Id": 8733688541086828833,
+                    "ArticulationConfiguration": {
+                        "entityId": "",
+                        "Articulation Joint Type": 1,
+                        "Local Rotation": [
+                            0.0,
+                            -90.0,
+                            0.0
+                        ],
+                        "Angular Limit Negative": 360.0,
+                        "Angular Limit Positive": -360.0,
+                        "Motor configuration": {
+                            "UseMotor": true,
+                            "ForceLimit": 1000.0,
+                            "Stiffness": 2000.0,
+                            "Damping": 300.0
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 6825910910262722001,
+                    "DisabledComponents": {
+                        "EditorRigidBodyComponent": {
+                            "$type": "EditorRigidBodyComponent",
+                            "Id": 15972914335770594700,
+                            "Configuration": {
+                                "entityId": "",
+                                "Compute Mass": false,
+                                "Mass": 3.700000047683716,
+                                "Compute COM": false,
+                                "Compute inertia": false,
+                                "Inertia tensor": [
+                                    0.014972352422773838,
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    0.014972352422773838,
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    0.01040625013411045
+                                ]
+                            },
+                            "PhysXSpecificConfiguration": {
+                                "SolverPositionIterations": 40,
+                                "SolverVelocityIterations": 10
+                            }
+                        }
+                    }
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5640486391480513514
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 688801696365909734,
+                    "Child Entity Order": [
+                        "Entity_[686102099607]",
+                        "Entity_[625972557463]"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 16922237610155443047
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 4050385619548902488
+                },
+                "EditorMeshColliderComponent": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 13139834304023403792,
+                    "ColliderConfiguration": {
+                        "Rotation": [
+                            0.0,
+                            0.0,
+                            1.0,
+                            6.123234262925839e-17
+                        ],
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "DefaultMaterial"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "PhysicsAsset": {
+                            "Asset": {
+                                "assetId": {
+                                    "guid": "{2A2FBD34-A2D2-562C-B8C8-A5AA97F5BEAB}",
+                                    "subId": 1468337438
+                                },
+                                "assetHint": "assets/urdfimporter/783534404_ur.urdf/shoulder.pxmesh"
+                            },
+                            "Configuration": {
+                                "PhysicsAsset": {
+                                    "assetId": {
+                                        "guid": "{2A2FBD34-A2D2-562C-B8C8-A5AA97F5BEAB}",
+                                        "subId": 1468337438
+                                    },
+                                    "loadBehavior": "QueueLoad",
+                                    "assetHint": "assets/urdfimporter/783534404_ur.urdf/shoulder.pxmesh"
+                                },
+                                "UseMaterialsFromAsset": false
+                            }
+                        }
+                    }
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 3262191907414126292
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17804401019373081075,
+                    "PendingComponents": {
+                        "EditorHingeJointComponent": {
+                            "$type": "EditorHingeJointComponent",
+                            "Id": 1643240907085891067,
+                            "Configuration": {
+                                "Local Rotation": [
+                                    0.0,
+                                    -89.99999237060547,
+                                    0.0
+                                ],
+                                "Parent Entity": "Entity_[651742361239]",
+                                "Child Entity": "Entity_[698987001495]"
+                            },
+                            "Angular Limit": {
+                                "Positive Limit": 360.0,
+                                "Negative Limit": -360.0
+                            }
+                        }
+                    }
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 7883156835889995140
+                },
+                "ROS2FrameComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 18299435543689378797,
+                    "m_template": {
+                        "$type": "ROS2FrameComponent",
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "shoulder_link",
+                        "Joint Name": "shoulder_pan_joint",
+                        "Publish Transform": false
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11970611978368704933,
+                    "Parent Entity": "Entity_[651742361239]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.0,
+                            0.0,
+                            0.08915899693965912
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[703281968791]": {
+            "Id": "Entity_[703281968791]",
+            "Name": "wrist_3_link",
+            "Components": {
+                "EditorArticulationLinkComponent": {
+                    "$type": "EditorArticulationLinkComponent",
+                    "Id": 15698341859360831512,
+                    "ArticulationConfiguration": {
+                        "entityId": "",
+                        "Articulation Joint Type": 1,
+                        "Local Rotation": [
+                            0.0,
+                            -90.0,
+                            0.0
+                        ],
+                        "Angular Limit Negative": 360.0,
+                        "Angular Limit Positive": -360.0,
+                        "Motor configuration": {
+                            "UseMotor": true,
+                            "ForceLimit": 1000.0,
+                            "Stiffness": 2000.0,
+                            "Damping": 300.0
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 453233964865915281,
+                    "DisabledComponents": {
+                        "EditorRigidBodyComponent": {
+                            "$type": "EditorRigidBodyComponent",
+                            "Id": 5624832871562135019,
+                            "Configuration": {
+                                "entityId": "",
+                                "Compute Mass": false,
+                                "Mass": 0.18790000677108765,
+                                "Compute COM": false,
+                                "Centre of mass offset": [
+                                    0.0,
+                                    0.0,
+                                    -0.015250000171363354
+                                ],
+                                "Compute inertia": false,
+                                "Inertia tensor": [
+                                    0.00008062472625169903,
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    0.00008062472625169903,
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    0.00013211718760430813
+                                ]
+                            },
+                            "PhysXSpecificConfiguration": {
+                                "SolverPositionIterations": 40,
+                                "SolverVelocityIterations": 10
+                            }
+                        }
+                    }
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 12351337672897447763
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 17507704831636304945,
+                    "Child Entity Order": [
+                        "Entity_[660332295831]",
+                        "Entity_[630267524759]",
+                        "Entity_[677512165015]"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13574068365038325125
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 9054359797261818210
+                },
+                "EditorMeshColliderComponent": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 10429166737180254797,
+                    "ColliderConfiguration": {
+                        "Position": [
+                            0.0,
+                            0.0,
+                            -0.08179999887943268
+                        ],
+                        "Rotation": [
+                            0.7071067690849304,
+                            0.0,
+                            0.0,
+                            0.7071067690849304
+                        ],
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "DefaultMaterial"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "PhysicsAsset": {
+                            "Asset": {
+                                "assetId": {
+                                    "guid": "{2825F82C-8267-5AFB-93C3-0173E7CD8B0E}",
+                                    "subId": 885361371
+                                },
+                                "assetHint": "assets/urdfimporter/783534404_ur.urdf/wrist3.pxmesh"
+                            },
+                            "Configuration": {
+                                "PhysicsAsset": {
+                                    "assetId": {
+                                        "guid": "{2825F82C-8267-5AFB-93C3-0173E7CD8B0E}",
+                                        "subId": 885361371
+                                    },
+                                    "loadBehavior": "QueueLoad",
+                                    "assetHint": "assets/urdfimporter/783534404_ur.urdf/wrist3.pxmesh"
+                                },
+                                "UseMaterialsFromAsset": false
+                            }
+                        }
+                    }
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 16240469739370387253
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 13002095070005706399,
+                    "PendingComponents": {
+                        "EditorHingeJointComponent": {
+                            "$type": "EditorHingeJointComponent",
+                            "Id": 16883181557595541209,
+                            "Configuration": {
+                                "Local Rotation": [
+                                    0.0,
+                                    -89.99999237060547,
+                                    0.0
+                                ],
+                                "Parent Entity": "Entity_[673217197719]",
+                                "Child Entity": "Entity_[703281968791]"
+                            },
+                            "Angular Limit": {
+                                "Positive Limit": 360.0,
+                                "Negative Limit": -360.0
+                            }
+                        }
+                    }
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 647752823523104838
+                },
+                "ROS2FrameComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 1787384002178001588,
+                    "m_template": {
+                        "$type": "ROS2FrameComponent",
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "wrist_3_link",
+                        "Joint Name": "wrist_3_joint",
+                        "Publish Transform": false
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 14966459619236809864,
+                    "Parent Entity": "Entity_[673217197719]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.0,
+                            0.08229997754096985,
+                            1.257285475730896e-8
+                        ],
+                        "Rotate": [
+                            -90.00001525878906,
+                            -1.3559519403108056e-28,
+                            3.791516178933426e-22
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Assets/ur5Moveit.prefab
+++ b/Assets/ur5Moveit.prefab
@@ -77,40 +77,7 @@
                 },
                 "EditorDisabledCompositionComponent": {
                     "$type": "EditorDisabledCompositionComponent",
-                    "Id": 10398996226318864671,
-                    "DisabledComponents": {
-                        "EditorRigidBodyComponent": {
-                            "$type": "EditorRigidBodyComponent",
-                            "Id": 2516350535976444155,
-                            "Configuration": {
-                                "entityId": "",
-                                "Compute Mass": false,
-                                "Mass": 2.2750000953674316,
-                                "Compute COM": false,
-                                "Centre of mass offset": [
-                                    -0.19612500071525574,
-                                    0.0,
-                                    0.016499999910593033
-                                ],
-                                "Compute inertia": false,
-                                "Inertia tensor": [
-                                    0.03121679089963436,
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    0.03121679089963436,
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    0.004095000214874744
-                                ]
-                            },
-                            "PhysXSpecificConfiguration": {
-                                "SolverPositionIterations": 40,
-                                "SolverVelocityIterations": 10
-                            }
-                        }
-                    }
+                    "Id": 10398996226318864671
                 },
                 "EditorEntityIconComponent": {
                     "$type": "EditorEntityIconComponent",
@@ -184,26 +151,7 @@
                 },
                 "EditorPendingCompositionComponent": {
                     "$type": "EditorPendingCompositionComponent",
-                    "Id": 7487096221790961974,
-                    "PendingComponents": {
-                        "EditorHingeJointComponent": {
-                            "$type": "EditorHingeJointComponent",
-                            "Id": 15804288157601571380,
-                            "Configuration": {
-                                "Local Rotation": [
-                                    0.0,
-                                    -89.99999237060547,
-                                    0.0
-                                ],
-                                "Parent Entity": "Entity_[625972557463]",
-                                "Child Entity": "Entity_[617382622871]"
-                            },
-                            "Angular Limit": {
-                                "Positive Limit": 180.0,
-                                "Negative Limit": -180.0
-                            }
-                        }
-                    }
+                    "Id": 7487096221790961974
                 },
                 "EditorVisibilityComponent": {
                     "$type": "EditorVisibilityComponent",
@@ -338,40 +286,7 @@
                 },
                 "EditorDisabledCompositionComponent": {
                     "$type": "EditorDisabledCompositionComponent",
-                    "Id": 15721472470196073362,
-                    "DisabledComponents": {
-                        "EditorRigidBodyComponent": {
-                            "$type": "EditorRigidBodyComponent",
-                            "Id": 13411689545511788138,
-                            "Configuration": {
-                                "entityId": "",
-                                "Compute Mass": false,
-                                "Mass": 8.392999649047852,
-                                "Compute COM": false,
-                                "Centre of mass offset": [
-                                    -0.21250000596046448,
-                                    0.0,
-                                    0.13600000739097595
-                                ],
-                                "Compute inertia": false,
-                                "Inertia tensor": [
-                                    0.13388578593730927,
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    0.13388578593730927,
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    0.01510739978402853
-                                ]
-                            },
-                            "PhysXSpecificConfiguration": {
-                                "SolverPositionIterations": 40,
-                                "SolverVelocityIterations": 10
-                            }
-                        }
-                    }
+                    "Id": 15721472470196073362
                 },
                 "EditorEntityIconComponent": {
                     "$type": "EditorEntityIconComponent",
@@ -445,26 +360,7 @@
                 },
                 "EditorPendingCompositionComponent": {
                     "$type": "EditorPendingCompositionComponent",
-                    "Id": 14425183701703761385,
-                    "PendingComponents": {
-                        "EditorHingeJointComponent": {
-                            "$type": "EditorHingeJointComponent",
-                            "Id": 3987400519655772359,
-                            "Configuration": {
-                                "Local Rotation": [
-                                    0.0,
-                                    -89.99999237060547,
-                                    0.0
-                                ],
-                                "Parent Entity": "Entity_[698987001495]",
-                                "Child Entity": "Entity_[625972557463]"
-                            },
-                            "Angular Limit": {
-                                "Positive Limit": 360.0,
-                                "Negative Limit": -360.0
-                            }
-                        }
-                    }
+                    "Id": 14425183701703761385
                 },
                 "EditorVisibilityComponent": {
                     "$type": "EditorVisibilityComponent",
@@ -530,17 +426,7 @@
                 },
                 "EditorPendingCompositionComponent": {
                     "$type": "EditorPendingCompositionComponent",
-                    "Id": 14307318628094693385,
-                    "PendingComponents": {
-                        "EditorFixedJointComponent": {
-                            "$type": "EditorFixedJointComponent",
-                            "Id": 2661907883375729967,
-                            "Configuration": {
-                                "Parent Entity": "",
-                                "Child Entity": ""
-                            }
-                        }
-                    }
+                    "Id": 14307318628094693385
                 },
                 "EditorVisibilityComponent": {
                     "$type": "EditorVisibilityComponent",
@@ -603,17 +489,7 @@
                 },
                 "EditorPendingCompositionComponent": {
                     "$type": "EditorPendingCompositionComponent",
-                    "Id": 17171151966305139016,
-                    "PendingComponents": {
-                        "EditorFixedJointComponent": {
-                            "$type": "EditorFixedJointComponent",
-                            "Id": 7046635627295538536,
-                            "Configuration": {
-                                "Parent Entity": "",
-                                "Child Entity": ""
-                            }
-                        }
-                    }
+                    "Id": 17171151966305139016
                 },
                 "EditorVisibilityComponent": {
                     "$type": "EditorVisibilityComponent",
@@ -859,35 +735,7 @@
                 },
                 "EditorDisabledCompositionComponent": {
                     "$type": "EditorDisabledCompositionComponent",
-                    "Id": 13678366325942524724,
-                    "DisabledComponents": {
-                        "EditorRigidBodyComponent": {
-                            "$type": "EditorRigidBodyComponent",
-                            "Id": 11316019482129754262,
-                            "Configuration": {
-                                "entityId": "",
-                                "Compute Mass": false,
-                                "Mass": 4.0,
-                                "Compute COM": false,
-                                "Compute inertia": false,
-                                "Inertia tensor": [
-                                    0.004433331545442343,
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    0.004433331545442343,
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    0.007200000341981649
-                                ]
-                            },
-                            "PhysXSpecificConfiguration": {
-                                "SolverPositionIterations": 40,
-                                "SolverVelocityIterations": 10
-                            }
-                        }
-                    }
+                    "Id": 13678366325942524724
                 },
                 "EditorEntityIconComponent": {
                     "$type": "EditorEntityIconComponent",
@@ -956,17 +804,7 @@
                 },
                 "EditorPendingCompositionComponent": {
                     "$type": "EditorPendingCompositionComponent",
-                    "Id": 13046724823623780661,
-                    "PendingComponents": {
-                        "EditorFixedJointComponent": {
-                            "$type": "EditorFixedJointComponent",
-                            "Id": 2942888710629582036,
-                            "Configuration": {
-                                "Parent Entity": "Entity_[664627263127]",
-                                "Child Entity": "Entity_[651742361239]"
-                            }
-                        }
-                    }
+                    "Id": 13046724823623780661
                 },
                 "EditorVisibilityComponent": {
                     "$type": "EditorVisibilityComponent",
@@ -1026,35 +864,7 @@
                 },
                 "EditorDisabledCompositionComponent": {
                     "$type": "EditorDisabledCompositionComponent",
-                    "Id": 6283366667922547963,
-                    "DisabledComponents": {
-                        "EditorRigidBodyComponent": {
-                            "$type": "EditorRigidBodyComponent",
-                            "Id": 9083091634387490518,
-                            "Configuration": {
-                                "entityId": "",
-                                "Compute Mass": false,
-                                "Mass": 1.218999981880188,
-                                "Compute COM": false,
-                                "Compute inertia": false,
-                                "Inertia tensor": [
-                                    0.0020138886757194996,
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    0.0020138886757194996,
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    0.0021941999439150095
-                                ]
-                            },
-                            "PhysXSpecificConfiguration": {
-                                "SolverPositionIterations": 40,
-                                "SolverVelocityIterations": 10
-                            }
-                        }
-                    }
+                    "Id": 6283366667922547963
                 },
                 "EditorEntityIconComponent": {
                     "$type": "EditorEntityIconComponent",
@@ -1128,26 +938,7 @@
                 },
                 "EditorPendingCompositionComponent": {
                     "$type": "EditorPendingCompositionComponent",
-                    "Id": 4974049491368840350,
-                    "PendingComponents": {
-                        "EditorHingeJointComponent": {
-                            "$type": "EditorHingeJointComponent",
-                            "Id": 15082905903567508890,
-                            "Configuration": {
-                                "Local Rotation": [
-                                    0.0,
-                                    -89.99999237060547,
-                                    0.0
-                                ],
-                                "Parent Entity": "Entity_[617382622871]",
-                                "Child Entity": "Entity_[656037328535]"
-                            },
-                            "Angular Limit": {
-                                "Positive Limit": 360.0,
-                                "Negative Limit": -360.0
-                            }
-                        }
-                    }
+                    "Id": 4974049491368840350
                 },
                 "EditorVisibilityComponent": {
                     "$type": "EditorVisibilityComponent",
@@ -1292,17 +1083,7 @@
                 },
                 "EditorPendingCompositionComponent": {
                     "$type": "EditorPendingCompositionComponent",
-                    "Id": 18098854983186689422,
-                    "PendingComponents": {
-                        "EditorFixedJointComponent": {
-                            "$type": "EditorFixedJointComponent",
-                            "Id": 2540807411163674559,
-                            "Configuration": {
-                                "Parent Entity": "",
-                                "Child Entity": ""
-                            }
-                        }
-                    }
+                    "Id": 18098854983186689422
                 },
                 "EditorVisibilityComponent": {
                     "$type": "EditorVisibilityComponent",
@@ -1398,17 +1179,7 @@
                 },
                 "EditorPendingCompositionComponent": {
                     "$type": "EditorPendingCompositionComponent",
-                    "Id": 12295804609010388912,
-                    "PendingComponents": {
-                        "EditorFixedJointComponent": {
-                            "$type": "EditorFixedJointComponent",
-                            "Id": 18274029838859631499,
-                            "Configuration": {
-                                "Parent Entity": "",
-                                "Child Entity": ""
-                            }
-                        }
-                    }
+                    "Id": 12295804609010388912
                 },
                 "EditorVisibilityComponent": {
                     "$type": "EditorVisibilityComponent",
@@ -1468,35 +1239,7 @@
                 },
                 "EditorDisabledCompositionComponent": {
                     "$type": "EditorDisabledCompositionComponent",
-                    "Id": 17617519167387097473,
-                    "DisabledComponents": {
-                        "EditorRigidBodyComponent": {
-                            "$type": "EditorRigidBodyComponent",
-                            "Id": 2487664085652031084,
-                            "Configuration": {
-                                "entityId": "",
-                                "Compute Mass": false,
-                                "Mass": 1.218999981880188,
-                                "Compute COM": false,
-                                "Compute inertia": false,
-                                "Inertia tensor": [
-                                    0.0018310388550162315,
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    0.0018310388550162315,
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    0.0021941999439150095
-                                ]
-                            },
-                            "PhysXSpecificConfiguration": {
-                                "SolverPositionIterations": 40,
-                                "SolverVelocityIterations": 10
-                            }
-                        }
-                    }
+                    "Id": 17617519167387097473
                 },
                 "EditorEntityIconComponent": {
                     "$type": "EditorEntityIconComponent",
@@ -1564,26 +1307,7 @@
                 },
                 "EditorPendingCompositionComponent": {
                     "$type": "EditorPendingCompositionComponent",
-                    "Id": 2495576720337268932,
-                    "PendingComponents": {
-                        "EditorHingeJointComponent": {
-                            "$type": "EditorHingeJointComponent",
-                            "Id": 4228821168727166008,
-                            "Configuration": {
-                                "Local Rotation": [
-                                    0.0,
-                                    -89.99999237060547,
-                                    0.0
-                                ],
-                                "Parent Entity": "Entity_[656037328535]",
-                                "Child Entity": "Entity_[673217197719]"
-                            },
-                            "Angular Limit": {
-                                "Positive Limit": 360.0,
-                                "Negative Limit": -360.0
-                            }
-                        }
-                    }
+                    "Id": 2495576720337268932
                 },
                 "EditorVisibilityComponent": {
                     "$type": "EditorVisibilityComponent",
@@ -1651,17 +1375,7 @@
                 },
                 "EditorPendingCompositionComponent": {
                     "$type": "EditorPendingCompositionComponent",
-                    "Id": 3768930271661577407,
-                    "PendingComponents": {
-                        "EditorFixedJointComponent": {
-                            "$type": "EditorFixedJointComponent",
-                            "Id": 8265112374632981275,
-                            "Configuration": {
-                                "Parent Entity": "",
-                                "Child Entity": ""
-                            }
-                        }
-                    }
+                    "Id": 3768930271661577407
                 },
                 "EditorVisibilityComponent": {
                     "$type": "EditorVisibilityComponent",
@@ -1700,19 +1414,7 @@
             "Components": {
                 "EditorDisabledCompositionComponent": {
                     "$type": "EditorDisabledCompositionComponent",
-                    "Id": 17758815968857029180,
-                    "DisabledComponents": {
-                        "ROS2RobotControlComponent": {
-                            "$type": "GenericComponentWrapper",
-                            "Id": 5958796147330969134,
-                            "m_template": {
-                                "$type": "ROS2RobotControlComponent",
-                                "SubscriberConfiguration": {
-                                    "Topic": "cmd_vel"
-                                }
-                            }
-                        }
-                    }
+                    "Id": 17758815968857029180
                 },
                 "EditorEntityIconComponent": {
                     "$type": "EditorEntityIconComponent",
@@ -1976,35 +1678,7 @@
                 },
                 "EditorDisabledCompositionComponent": {
                     "$type": "EditorDisabledCompositionComponent",
-                    "Id": 6825910910262722001,
-                    "DisabledComponents": {
-                        "EditorRigidBodyComponent": {
-                            "$type": "EditorRigidBodyComponent",
-                            "Id": 15972914335770594700,
-                            "Configuration": {
-                                "entityId": "",
-                                "Compute Mass": false,
-                                "Mass": 3.700000047683716,
-                                "Compute COM": false,
-                                "Compute inertia": false,
-                                "Inertia tensor": [
-                                    0.014972352422773838,
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    0.014972352422773838,
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    0.01040625013411045
-                                ]
-                            },
-                            "PhysXSpecificConfiguration": {
-                                "SolverPositionIterations": 40,
-                                "SolverVelocityIterations": 10
-                            }
-                        }
-                    }
+                    "Id": 6825910910262722001
                 },
                 "EditorEntityIconComponent": {
                     "$type": "EditorEntityIconComponent",
@@ -2073,26 +1747,7 @@
                 },
                 "EditorPendingCompositionComponent": {
                     "$type": "EditorPendingCompositionComponent",
-                    "Id": 17804401019373081075,
-                    "PendingComponents": {
-                        "EditorHingeJointComponent": {
-                            "$type": "EditorHingeJointComponent",
-                            "Id": 1643240907085891067,
-                            "Configuration": {
-                                "Local Rotation": [
-                                    0.0,
-                                    -89.99999237060547,
-                                    0.0
-                                ],
-                                "Parent Entity": "Entity_[651742361239]",
-                                "Child Entity": "Entity_[698987001495]"
-                            },
-                            "Angular Limit": {
-                                "Positive Limit": 360.0,
-                                "Negative Limit": -360.0
-                            }
-                        }
-                    }
+                    "Id": 17804401019373081075
                 },
                 "EditorVisibilityComponent": {
                     "$type": "EditorVisibilityComponent",
@@ -2152,40 +1807,7 @@
                 },
                 "EditorDisabledCompositionComponent": {
                     "$type": "EditorDisabledCompositionComponent",
-                    "Id": 453233964865915281,
-                    "DisabledComponents": {
-                        "EditorRigidBodyComponent": {
-                            "$type": "EditorRigidBodyComponent",
-                            "Id": 5624832871562135019,
-                            "Configuration": {
-                                "entityId": "",
-                                "Compute Mass": false,
-                                "Mass": 0.18790000677108765,
-                                "Compute COM": false,
-                                "Centre of mass offset": [
-                                    0.0,
-                                    0.0,
-                                    -0.015250000171363354
-                                ],
-                                "Compute inertia": false,
-                                "Inertia tensor": [
-                                    0.00008062472625169903,
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    0.00008062472625169903,
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    0.00013211718760430813
-                                ]
-                            },
-                            "PhysXSpecificConfiguration": {
-                                "SolverPositionIterations": 40,
-                                "SolverVelocityIterations": 10
-                            }
-                        }
-                    }
+                    "Id": 453233964865915281
                 },
                 "EditorEntityIconComponent": {
                     "$type": "EditorEntityIconComponent",
@@ -2260,26 +1882,7 @@
                 },
                 "EditorPendingCompositionComponent": {
                     "$type": "EditorPendingCompositionComponent",
-                    "Id": 13002095070005706399,
-                    "PendingComponents": {
-                        "EditorHingeJointComponent": {
-                            "$type": "EditorHingeJointComponent",
-                            "Id": 16883181557595541209,
-                            "Configuration": {
-                                "Local Rotation": [
-                                    0.0,
-                                    -89.99999237060547,
-                                    0.0
-                                ],
-                                "Parent Entity": "Entity_[673217197719]",
-                                "Child Entity": "Entity_[703281968791]"
-                            },
-                            "Angular Limit": {
-                                "Positive Limit": 360.0,
-                                "Negative Limit": -360.0
-                            }
-                        }
-                    }
+                    "Id": 13002095070005706399
                 },
                 "EditorVisibilityComponent": {
                     "$type": "EditorVisibilityComponent",

--- a/Levels/ur5_moveit/ur5_moveit.prefab
+++ b/Levels/ur5_moveit/ur5_moveit.prefab
@@ -1,0 +1,2642 @@
+{
+    "ContainerEntity": {
+        "Id": "Entity_[1146574390643]",
+        "Name": "Level",
+        "Components": {
+            "Component_[10641544592923449938]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 10641544592923449938
+            },
+            "Component_[12039882709170782873]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 12039882709170782873
+            },
+            "Component_[12265484671603697631]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12265484671603697631
+            },
+            "Component_[14126657869720434043]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 14126657869720434043,
+                "Child Entity Order": [
+                    "Entity_[1176639161715]",
+                    "Instance_[1147111098351]/ContainerEntity",
+                    "Entity_[1039454339336]"
+                ]
+            },
+            "Component_[15230859088967841193]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 15230859088967841193,
+                "Parent Entity": ""
+            },
+            "Component_[16239496886950819870]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 16239496886950819870
+            },
+            "Component_[5688118765544765547]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 5688118765544765547
+            },
+            "Component_[7247035804068349658]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 7247035804068349658
+            },
+            "Component_[9307224322037797205]": {
+                "$type": "EditorLockComponent",
+                "Id": 9307224322037797205
+            },
+            "Component_[9562516168917670048]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 9562516168917670048
+            },
+            "LocalViewBookmarkComponent": {
+                "$type": "LocalViewBookmarkComponent",
+                "Id": 12916931753874717935,
+                "LocalBookmarkFileName": "test_1687942878407796046.setreg"
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[1039454339336]": {
+            "Id": "Entity_[1039454339336]",
+            "Name": "camera",
+            "Components": {
+                "EditorCameraComponent": {
+                    "$type": "{CA11DA46-29FF-4083-B5F6-E02C3A8C3A3D} EditorCameraComponent",
+                    "Id": 18033703551470768931
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 15675038152426376748
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 18271385702599742103
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 11614801507590427336
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11388614056313671020
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 15692905186550689549
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 14030181398113243598
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 12697526036162445465
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 5229161697156541718
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10529897132897395029,
+                    "Parent Entity": "Entity_[1146574390643]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.0,
+                            -1.2175464630126953,
+                            1.206383466720581
+                        ],
+                        "Rotate": [
+                            -32.15428161621094,
+                            0.8644461035728455,
+                            -1.3748327493667603
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[1155164325235]": {
+            "Id": "Entity_[1155164325235]",
+            "Name": "Sun",
+            "Components": {
+                "Component_[13620450453324765907]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 13620450453324765907
+                },
+                "Component_[2134313378593666258]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 2134313378593666258
+                },
+                "Component_[234010807770404186]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 234010807770404186
+                },
+                "Component_[2970359110423865725]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2970359110423865725
+                },
+                "Component_[3722854130373041803]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 3722854130373041803
+                },
+                "Component_[5992533738676323195]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 5992533738676323195
+                },
+                "Component_[7378860763541895402]": {
+                    "$type": "AZ::Render::EditorDirectionalLightComponent",
+                    "Id": 7378860763541895402,
+                    "Controller": {
+                        "Configuration": {
+                            "Intensity": 1.0,
+                            "CameraEntityId": "",
+                            "ShadowFilterMethod": 1
+                        }
+                    }
+                },
+                "Component_[7892834440890947578]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 7892834440890947578,
+                    "Parent Entity": "Entity_[1176639161715]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.0,
+                            0.0,
+                            13.487043380737305
+                        ],
+                        "Rotate": [
+                            -76.13099670410156,
+                            -0.847000002861023,
+                            -15.8100004196167
+                        ]
+                    }
+                },
+                "Component_[8599729549570828259]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 8599729549570828259
+                },
+                "Component_[952797371922080273]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 952797371922080273
+                }
+            }
+        },
+        "Entity_[1159459292531]": {
+            "Id": "Entity_[1159459292531]",
+            "Name": "Ground",
+            "Components": {
+                "Component_[12260880513256986252]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 12260880513256986252
+                },
+                "Component_[13711420870643673468]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13711420870643673468
+                },
+                "Component_[138002849734991713]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 138002849734991713
+                },
+                "Component_[16578565737331764849]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 16578565737331764849,
+                    "Parent Entity": "Entity_[1176639161715]"
+                },
+                "Component_[16919232076966545697]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 16919232076966545697
+                },
+                "Component_[4228479570410194639]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 4228479570410194639
+                },
+                "Component_[5182430712893438093]": {
+                    "$type": "EditorMaterialComponent",
+                    "Id": 5182430712893438093
+                },
+                "Component_[5245524694917323904]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 5245524694917323904,
+                    "ColliderConfiguration": {
+                        "Position": [
+                            0.0,
+                            0.0,
+                            -0.5
+                        ],
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                512.0,
+                                512.0,
+                                1.0
+                            ]
+                        }
+                    },
+                    "DebugDrawSettings": {
+                        "LocallyEnabled": false
+                    }
+                },
+                "Component_[5675108321710651991]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 5675108321710651991,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{0CD745C0-6AA8-569A-A68A-73A3270986C4}",
+                                    "subId": 277889906
+                                },
+                                "assetHint": "objects/groudplane/groundplane_512x512m.azmodel"
+                            }
+                        }
+                    }
+                },
+                "Component_[5681893399601237518]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 5681893399601237518
+                },
+                "Component_[592692962543397545]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 592692962543397545
+                },
+                "Component_[7090012899106946164]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7090012899106946164
+                },
+                "Component_[9410832619875640998]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9410832619875640998
+                }
+            }
+        },
+        "Entity_[1163754259827]": {
+            "Id": "Entity_[1163754259827]",
+            "Name": "Camera",
+            "Components": {
+                "Component_[11895140916889160460]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 11895140916889160460
+                },
+                "Component_[16880285896855930892]": {
+                    "$type": "{CA11DA46-29FF-4083-B5F6-E02C3A8C3A3D} EditorCameraComponent",
+                    "Id": 16880285896855930892,
+                    "Controller": {
+                        "Configuration": {
+                            "Field of View": 55.0,
+                            "MakeActiveViewOnActivation": false
+                        }
+                    }
+                },
+                "Component_[17187464423780271193]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 17187464423780271193
+                },
+                "Component_[17495696818315413311]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 17495696818315413311
+                },
+                "Component_[18086214374043522055]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 18086214374043522055,
+                    "Parent Entity": "Entity_[1176639161715]",
+                    "Transform Data": {
+                        "Translate": [
+                            -2.3000001907348633,
+                            -3.9368600845336914,
+                            1.0
+                        ],
+                        "Rotate": [
+                            -4.964685440063477,
+                            1.5077779293060303,
+                            -16.851835250854492
+                        ]
+                    }
+                },
+                "Component_[2654521436129313160]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 2654521436129313160
+                },
+                "Component_[5265045084611556958]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 5265045084611556958
+                },
+                "Component_[7169798125182238623]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7169798125182238623
+                },
+                "Component_[7255796294953281766]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 7255796294953281766,
+                    "m_template": {
+                        "$type": "FlyCameraInputComponent"
+                    }
+                },
+                "Component_[8866210352157164042]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 8866210352157164042
+                },
+                "Component_[9129253381063760879]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 9129253381063760879
+                }
+            }
+        },
+        "Entity_[1168049227123]": {
+            "Id": "Entity_[1168049227123]",
+            "Name": "Grid",
+            "Components": {
+                "Component_[11443347433215807130]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 11443347433215807130
+                },
+                "Component_[14249419413039427459]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14249419413039427459
+                },
+                "Component_[15448581635946161318]": {
+                    "$type": "AZ::Render::EditorGridComponent",
+                    "Id": 15448581635946161318,
+                    "Controller": {
+                        "Configuration": {
+                            "primarySpacing": 4.0,
+                            "primaryColor": [
+                                0.501960813999176,
+                                0.501960813999176,
+                                0.501960813999176
+                            ],
+                            "secondarySpacing": 0.5,
+                            "secondaryColor": [
+                                0.250980406999588,
+                                0.250980406999588,
+                                0.250980406999588
+                            ]
+                        }
+                    }
+                },
+                "Component_[1843303322527297409]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 1843303322527297409
+                },
+                "Component_[380249072065273654]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 380249072065273654,
+                    "Parent Entity": "Entity_[1176639161715]"
+                },
+                "Component_[7476660583684339787]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7476660583684339787
+                },
+                "Component_[7557626501215118375]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 7557626501215118375
+                },
+                "Component_[7984048488947365511]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 7984048488947365511
+                },
+                "Component_[8118181039276487398]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8118181039276487398
+                },
+                "Component_[9189909764215270515]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 9189909764215270515
+                }
+            }
+        },
+        "Entity_[1176639161715]": {
+            "Id": "Entity_[1176639161715]",
+            "Name": "Atom Default Environment",
+            "Components": {
+                "Component_[10757302973393310045]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10757302973393310045,
+                    "Parent Entity": "Entity_[1146574390643]"
+                },
+                "Component_[14505817420424255464]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14505817420424255464,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 10757302973393310045
+                        }
+                    ]
+                },
+                "Component_[14988041764659020032]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14988041764659020032
+                },
+                "Component_[15900837685796817138]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15900837685796817138
+                },
+                "Component_[3298767348226484884]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 3298767348226484884
+                },
+                "Component_[4076975109609220594]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 4076975109609220594
+                },
+                "Component_[5679760548946028854]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 5679760548946028854
+                },
+                "Component_[5855590796136709437]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 5855590796136709437,
+                    "Child Entity Order": [
+                        "Entity_[1155164325235]",
+                        "Entity_[1180934129011]",
+                        "Entity_[1168049227123]",
+                        "Entity_[1163754259827]",
+                        "Entity_[1159459292531]"
+                    ]
+                },
+                "Component_[9277695270015777859]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 9277695270015777859
+                }
+            }
+        },
+        "Entity_[1180934129011]": {
+            "Id": "Entity_[1180934129011]",
+            "Name": "Global Sky",
+            "Components": {
+                "Component_[11231930600558681245]": {
+                    "$type": "AZ::Render::EditorHDRiSkyboxComponent",
+                    "Id": 11231930600558681245,
+                    "Controller": {
+                        "Configuration": {
+                            "CubemapAsset": {
+                                "assetId": {
+                                    "guid": "{215E47FD-D181-5832-B1AB-91673ABF6399}",
+                                    "subId": 1000
+                                },
+                                "assetHint": "lightingpresets/highcontrast/goegap_4k_skyboxcm.exr.streamingimage"
+                            }
+                        }
+                    }
+                },
+                "Component_[1428633914413949476]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 1428633914413949476
+                },
+                "Component_[14936200426671614999]": {
+                    "$type": "AZ::Render::EditorImageBasedLightComponent",
+                    "Id": 14936200426671614999,
+                    "Controller": {
+                        "Configuration": {
+                            "diffuseImageAsset": {
+                                "assetId": {
+                                    "guid": "{3FD09945-D0F2-55C8-B9AF-B2FD421FE3BE}",
+                                    "subId": 3000
+                                },
+                                "assetHint": "lightingpresets/highcontrast/goegap_4k_iblglobalcm_ibldiffuse.exr.streamingimage"
+                            },
+                            "specularImageAsset": {
+                                "assetId": {
+                                    "guid": "{3FD09945-D0F2-55C8-B9AF-B2FD421FE3BE}",
+                                    "subId": 2000
+                                },
+                                "assetHint": "lightingpresets/highcontrast/goegap_4k_iblglobalcm_iblspecular.exr.streamingimage"
+                            }
+                        }
+                    },
+                    "diffuseImageAsset": {
+                        "assetId": {
+                            "guid": "{3FD09945-D0F2-55C8-B9AF-B2FD421FE3BE}",
+                            "subId": 3000
+                        },
+                        "assetHint": "lightingpresets/highcontrast/goegap_4k_iblglobalcm_ibldiffuse.exr.streamingimage"
+                    },
+                    "specularImageAsset": {
+                        "assetId": {
+                            "guid": "{3FD09945-D0F2-55C8-B9AF-B2FD421FE3BE}",
+                            "subId": 2000
+                        },
+                        "assetHint": "lightingpresets/highcontrast/goegap_4k_iblglobalcm_iblspecular.exr.streamingimage"
+                    }
+                },
+                "Component_[14994774102579326069]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 14994774102579326069
+                },
+                "Component_[15417479889044493340]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15417479889044493340
+                },
+                "Component_[15826613364991382688]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 15826613364991382688
+                },
+                "Component_[1665003113283562343]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1665003113283562343
+                },
+                "Component_[3704934735944502280]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3704934735944502280
+                },
+                "Component_[5698542331457326479]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 5698542331457326479
+                },
+                "Component_[6644513399057217122]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6644513399057217122,
+                    "Parent Entity": "Entity_[1176639161715]"
+                },
+                "Component_[931091830724002070]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 931091830724002070
+                }
+            }
+        }
+    },
+    "Instances": {
+        "Instance_[1147111098351]": {
+            "Source": "Assets/Importer/urMoveit.prefab",
+            "Patches": [
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/TransformComponent/Parent Entity",
+                    "value": "../Entity_[1146574390643]"
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/TransformComponent/Transform Data/Translate/2",
+                    "value": 0.23211252689361572
+                },
+                {
+                    "op": "add",
+                    "path": "/Entities/Entity_[1202945673199]/Components/EditorArticulationLinkComponent",
+                    "value": {
+                        "$type": "EditorArticulationLinkComponent",
+                        "Id": 18004175037883671043,
+                        "ArticulationConfiguration": {
+                            "name": "",
+                            "position": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "orientation": [
+                                0.0,
+                                0.0,
+                                0.0,
+                                1.0
+                            ],
+                            "entityId": "",
+                            "startSimulationEnabled": true,
+                            "Fixed Base": false,
+                            "Self Collide": false,
+                            "Mass": 1.0,
+                            "Gravity Enabled": true,
+                            "Linear damping": 0.05000000074505806,
+                            "Angular damping": 0.15000000596046448,
+                            "Sleep threshold": 0.004999999888241291,
+                            "Start Asleep": false,
+                            "Centre of mass offset": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Maximum Angular Velocity": 100.0,
+                            "SolverPositionIterations": 4,
+                            "SolverVelocityIterations": 1,
+                            "Articulation Joint Type": 0,
+                            "Local Position": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Local Rotation": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Fix Joint Location": false,
+                            "Auto-calculate Lead frame": true,
+                            "Lead Local Position": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Lead Local Rotation": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Display Joint Setup": 1,
+                            "Is Limited": true,
+                            "Linear Limit Lower": -1.0,
+                            "Linear Limit Upper": 1.0,
+                            "Angular Limit Negative": -45.0,
+                            "Angular Limit Positive": 45.0,
+                            "Motor configuration": {
+                                "UseMotor": false,
+                                "ForceLimit": 1.0,
+                                "Stiffness": 1.0,
+                                "Damping": 1.0
+                            },
+                            "Armature": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Friction": 0.0,
+                            "Sensor Configurations": []
+                        }
+                    }
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1202945673199]/Components/EditorDisabledCompositionComponent/DisabledComponents",
+                    "value": {
+                        "EditorRigidBodyComponent": {
+                            "$type": "EditorRigidBodyComponent",
+                            "Id": 11316019482129754262,
+                            "Configuration": {
+                                "name": "",
+                                "position": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "orientation": [
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    1.0
+                                ],
+                                "entityId": "",
+                                "startSimulationEnabled": true,
+                                "Kinematic": false,
+                                "Initial linear velocity": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Initial angular velocity": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Linear damping": 0.05000000074505806,
+                                "Angular damping": 0.15000000596046448,
+                                "Sleep threshold": 0.004999999888241291,
+                                "Start Asleep": false,
+                                "Interpolate Motion": false,
+                                "Gravity Enabled": true,
+                                "CCD Enabled": false,
+                                "Compute Mass": false,
+                                "Lock Linear X": false,
+                                "Lock Linear Y": false,
+                                "Lock Linear Z": false,
+                                "Lock Angular X": false,
+                                "Lock Angular Y": false,
+                                "Lock Angular Z": false,
+                                "Mass": 4.0,
+                                "Compute COM": false,
+                                "Centre of mass offset": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Compute inertia": false,
+                                "Inertia tensor": [
+                                    0.004433331545442343,
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    0.004433331545442343,
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    0.007200000341981649
+                                ],
+                                "Maximum Angular Velocity": 100.0,
+                                "Include All Shapes In Mass": false,
+                                "CCD Min Advance": 0.15000000596046448,
+                                "CCD Friction": false,
+                                "Open PhysX Configuration": false,
+                                "Debug Draw Center of Mass": false
+                            },
+                            "PhysXSpecificConfiguration": {
+                                "SolverPositionIterations": 40,
+                                "SolverVelocityIterations": 10
+                            }
+                        }
+                    }
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1202945673199]/Components/EditorPendingCompositionComponent/PendingComponents",
+                    "value": {
+                        "EditorFixedJointComponent": {
+                            "$type": "EditorFixedJointComponent",
+                            "Id": 2942888710629582036,
+                            "Configuration": {
+                                "Local Position": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Local Rotation": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Fix Joint Location": false,
+                                "Parent Entity": "Entity_[1215830575087]",
+                                "Child Entity": "Entity_[1202945673199]",
+                                "Breakable": false,
+                                "Maximum Force": 1.0,
+                                "Maximum Torque": 1.0,
+                                "Display Debug": 1,
+                                "Select Lead on Snap": true,
+                                "Self Collide": false
+                            },
+                            "Component Mode": {}
+                        }
+                    }
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1202945673199]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "value": 1
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1202945673199]/Components/ROS2FrameComponent/m_template/Publish Transform",
+                    "value": false
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[1202945673199]/Components/EditorFixedJointComponent"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[1202945673199]/Components/EditorRigidBodyComponent"
+                },
+                {
+                    "op": "add",
+                    "path": "/Entities/Entity_[1207240640495]/Components/EditorArticulationLinkComponent",
+                    "value": {
+                        "$type": "EditorArticulationLinkComponent",
+                        "Id": 176615949713617667,
+                        "ArticulationConfiguration": {
+                            "name": "",
+                            "position": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "orientation": [
+                                0.0,
+                                0.0,
+                                0.0,
+                                1.0
+                            ],
+                            "entityId": "",
+                            "startSimulationEnabled": true,
+                            "Fixed Base": false,
+                            "Self Collide": false,
+                            "Mass": 1.0,
+                            "Gravity Enabled": true,
+                            "Linear damping": 0.05000000074505806,
+                            "Angular damping": 0.15000000596046448,
+                            "Sleep threshold": 0.004999999888241291,
+                            "Start Asleep": false,
+                            "Centre of mass offset": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Maximum Angular Velocity": 100.0,
+                            "SolverPositionIterations": 4,
+                            "SolverVelocityIterations": 1,
+                            "Articulation Joint Type": 0,
+                            "Local Position": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Local Rotation": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Fix Joint Location": false,
+                            "Auto-calculate Lead frame": true,
+                            "Lead Local Position": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Lead Local Rotation": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Display Joint Setup": 1,
+                            "Is Limited": true,
+                            "Linear Limit Lower": -1.0,
+                            "Linear Limit Upper": 1.0,
+                            "Angular Limit Negative": -45.0,
+                            "Angular Limit Positive": 45.0,
+                            "Motor configuration": {
+                                "UseMotor": false,
+                                "ForceLimit": 1.0,
+                                "Stiffness": 1.0,
+                                "Damping": 1.0
+                            },
+                            "Armature": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Friction": 0.0,
+                            "Sensor Configurations": []
+                        }
+                    }
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1207240640495]/Components/EditorPendingCompositionComponent/PendingComponents",
+                    "value": {
+                        "EditorFixedJointComponent": {
+                            "$type": "EditorFixedJointComponent",
+                            "Id": 18274029838859631499,
+                            "Configuration": {
+                                "Local Position": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Local Rotation": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Fix Joint Location": false,
+                                "Parent Entity": "",
+                                "Child Entity": "",
+                                "Breakable": false,
+                                "Maximum Force": 1.0,
+                                "Maximum Torque": 1.0,
+                                "Display Debug": 1,
+                                "Select Lead on Snap": true,
+                                "Self Collide": false
+                            },
+                            "Component Mode": {}
+                        }
+                    }
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1207240640495]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "value": 1
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1207240640495]/Components/ROS2FrameComponent/m_template/Publish Transform",
+                    "value": false
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[1207240640495]/Components/EditorFixedJointComponent"
+                },
+                {
+                    "op": "add",
+                    "path": "/Entities/Entity_[1224420509679]/Components/EditorArticulationLinkComponent",
+                    "value": {
+                        "$type": "EditorArticulationLinkComponent",
+                        "Id": 8733688541086828833,
+                        "ArticulationConfiguration": {
+                            "name": "",
+                            "position": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "orientation": [
+                                0.0,
+                                0.0,
+                                0.0,
+                                1.0
+                            ],
+                            "entityId": "",
+                            "startSimulationEnabled": true,
+                            "Fixed Base": false,
+                            "Self Collide": false,
+                            "Mass": 1.0,
+                            "Gravity Enabled": true,
+                            "Linear damping": 0.05000000074505806,
+                            "Angular damping": 0.15000000596046448,
+                            "Sleep threshold": 0.004999999888241291,
+                            "Start Asleep": false,
+                            "Centre of mass offset": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Maximum Angular Velocity": 100.0,
+                            "SolverPositionIterations": 4,
+                            "SolverVelocityIterations": 1,
+                            "Articulation Joint Type": 1,
+                            "Local Position": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Local Rotation": [
+                                0.0,
+                                -90.0,
+                                0.0
+                            ],
+                            "Fix Joint Location": false,
+                            "Auto-calculate Lead frame": true,
+                            "Lead Local Position": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Lead Local Rotation": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Display Joint Setup": 1,
+                            "Is Limited": true,
+                            "Linear Limit Lower": -1.0,
+                            "Linear Limit Upper": 1.0,
+                            "Angular Limit Negative": 360.0,
+                            "Angular Limit Positive": -360.0,
+                            "Motor configuration": {
+                                "UseMotor": true,
+                                "ForceLimit": 1000.0,
+                                "Stiffness": 2000.0,
+                                "Damping": 300.0
+                            },
+                            "Armature": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Friction": 0.0,
+                            "Sensor Configurations": []
+                        }
+                    }
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1224420509679]/Components/EditorDisabledCompositionComponent/DisabledComponents",
+                    "value": {
+                        "EditorRigidBodyComponent": {
+                            "$type": "EditorRigidBodyComponent",
+                            "Id": 15972914335770594700,
+                            "Configuration": {
+                                "name": "",
+                                "position": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "orientation": [
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    1.0
+                                ],
+                                "entityId": "",
+                                "startSimulationEnabled": true,
+                                "Kinematic": false,
+                                "Initial linear velocity": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Initial angular velocity": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Linear damping": 0.05000000074505806,
+                                "Angular damping": 0.15000000596046448,
+                                "Sleep threshold": 0.004999999888241291,
+                                "Start Asleep": false,
+                                "Interpolate Motion": false,
+                                "Gravity Enabled": true,
+                                "CCD Enabled": false,
+                                "Compute Mass": false,
+                                "Lock Linear X": false,
+                                "Lock Linear Y": false,
+                                "Lock Linear Z": false,
+                                "Lock Angular X": false,
+                                "Lock Angular Y": false,
+                                "Lock Angular Z": false,
+                                "Mass": 3.700000047683716,
+                                "Compute COM": false,
+                                "Centre of mass offset": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Compute inertia": false,
+                                "Inertia tensor": [
+                                    0.014972352422773838,
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    0.014972352422773838,
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    0.01040625013411045
+                                ],
+                                "Maximum Angular Velocity": 100.0,
+                                "Include All Shapes In Mass": false,
+                                "CCD Min Advance": 0.15000000596046448,
+                                "CCD Friction": false,
+                                "Open PhysX Configuration": false,
+                                "Debug Draw Center of Mass": false
+                            },
+                            "PhysXSpecificConfiguration": {
+                                "SolverPositionIterations": 40,
+                                "SolverVelocityIterations": 10
+                            }
+                        }
+                    }
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1224420509679]/Components/EditorPendingCompositionComponent/PendingComponents",
+                    "value": {
+                        "EditorHingeJointComponent": {
+                            "$type": "EditorHingeJointComponent",
+                            "Id": 1643240907085891067,
+                            "Configuration": {
+                                "Local Position": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Local Rotation": [
+                                    0.0,
+                                    -89.99999237060547,
+                                    0.0
+                                ],
+                                "Fix Joint Location": false,
+                                "Parent Entity": "Entity_[1202945673199]",
+                                "Child Entity": "Entity_[1224420509679]",
+                                "Breakable": false,
+                                "Maximum Force": 1.0,
+                                "Maximum Torque": 1.0,
+                                "Display Debug": 1,
+                                "Select Lead on Snap": true,
+                                "Self Collide": false
+                            },
+                            "Angular Limit": {
+                                "Standard Limit Configuration": {
+                                    "Name": "",
+                                    "Is Limited": true,
+                                    "Is Soft Limit": false,
+                                    "Tolerance": 0.10000000149011612,
+                                    "Damping": 20.0,
+                                    "Stiffness": 100.0
+                                },
+                                "Positive Limit": 360.0,
+                                "Negative Limit": -360.0
+                            },
+                            "Motor": {
+                                "UseMotor": false,
+                                "ForceLimit": 1.0
+                            },
+                            "Component Mode": {}
+                        }
+                    }
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1224420509679]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "value": 1
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1224420509679]/Components/ROS2FrameComponent/m_template/Publish Transform",
+                    "value": false
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[1224420509679]/Components/EditorHingeJointComponent"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[1224420509679]/Components/EditorRigidBodyComponent"
+                },
+                {
+                    "op": "add",
+                    "path": "/Entities/Entity_[1237305411567]/Components/EditorArticulationLinkComponent",
+                    "value": {
+                        "$type": "EditorArticulationLinkComponent",
+                        "Id": 6603734076359607423,
+                        "ArticulationConfiguration": {
+                            "name": "",
+                            "position": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "orientation": [
+                                0.0,
+                                0.0,
+                                0.0,
+                                1.0
+                            ],
+                            "entityId": "",
+                            "startSimulationEnabled": true,
+                            "Fixed Base": false,
+                            "Self Collide": false,
+                            "Mass": 1.0,
+                            "Gravity Enabled": true,
+                            "Linear damping": 0.05000000074505806,
+                            "Angular damping": 0.15000000596046448,
+                            "Sleep threshold": 0.004999999888241291,
+                            "Start Asleep": false,
+                            "Centre of mass offset": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Maximum Angular Velocity": 100.0,
+                            "SolverPositionIterations": 4,
+                            "SolverVelocityIterations": 1,
+                            "Articulation Joint Type": 1,
+                            "Local Position": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Local Rotation": [
+                                0.0,
+                                -90.0,
+                                0.0
+                            ],
+                            "Fix Joint Location": false,
+                            "Auto-calculate Lead frame": true,
+                            "Lead Local Position": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Lead Local Rotation": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Display Joint Setup": 1,
+                            "Is Limited": true,
+                            "Linear Limit Lower": -1.0,
+                            "Linear Limit Upper": 1.0,
+                            "Angular Limit Negative": 360.0,
+                            "Angular Limit Positive": -360.0,
+                            "Motor configuration": {
+                                "UseMotor": true,
+                                "ForceLimit": 1000.0,
+                                "Stiffness": 2000.0,
+                                "Damping": 300.0
+                            },
+                            "Armature": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Friction": 0.0,
+                            "Sensor Configurations": []
+                        }
+                    }
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1237305411567]/Components/EditorDisabledCompositionComponent/DisabledComponents",
+                    "value": {
+                        "EditorRigidBodyComponent": {
+                            "$type": "EditorRigidBodyComponent",
+                            "Id": 9083091634387490518,
+                            "Configuration": {
+                                "name": "",
+                                "position": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "orientation": [
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    1.0
+                                ],
+                                "entityId": "",
+                                "startSimulationEnabled": true,
+                                "Kinematic": false,
+                                "Initial linear velocity": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Initial angular velocity": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Linear damping": 0.05000000074505806,
+                                "Angular damping": 0.15000000596046448,
+                                "Sleep threshold": 0.004999999888241291,
+                                "Start Asleep": false,
+                                "Interpolate Motion": false,
+                                "Gravity Enabled": true,
+                                "CCD Enabled": false,
+                                "Compute Mass": false,
+                                "Lock Linear X": false,
+                                "Lock Linear Y": false,
+                                "Lock Linear Z": false,
+                                "Lock Angular X": false,
+                                "Lock Angular Y": false,
+                                "Lock Angular Z": false,
+                                "Mass": 1.218999981880188,
+                                "Compute COM": false,
+                                "Centre of mass offset": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Compute inertia": false,
+                                "Inertia tensor": [
+                                    0.0020138886757194996,
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    0.0020138886757194996,
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    0.0021941999439150095
+                                ],
+                                "Maximum Angular Velocity": 100.0,
+                                "Include All Shapes In Mass": false,
+                                "CCD Min Advance": 0.15000000596046448,
+                                "CCD Friction": false,
+                                "Open PhysX Configuration": false,
+                                "Debug Draw Center of Mass": false
+                            },
+                            "PhysXSpecificConfiguration": {
+                                "SolverPositionIterations": 40,
+                                "SolverVelocityIterations": 10
+                            }
+                        }
+                    }
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1237305411567]/Components/EditorPendingCompositionComponent/PendingComponents",
+                    "value": {
+                        "EditorHingeJointComponent": {
+                            "$type": "EditorHingeJointComponent",
+                            "Id": 15082905903567508890,
+                            "Configuration": {
+                                "Local Position": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Local Rotation": [
+                                    0.0,
+                                    -89.99999237060547,
+                                    0.0
+                                ],
+                                "Fix Joint Location": false,
+                                "Parent Entity": "Entity_[1211535607791]",
+                                "Child Entity": "Entity_[1237305411567]",
+                                "Breakable": false,
+                                "Maximum Force": 1.0,
+                                "Maximum Torque": 1.0,
+                                "Display Debug": 1,
+                                "Select Lead on Snap": true,
+                                "Self Collide": false
+                            },
+                            "Angular Limit": {
+                                "Standard Limit Configuration": {
+                                    "Name": "",
+                                    "Is Limited": true,
+                                    "Is Soft Limit": false,
+                                    "Tolerance": 0.10000000149011612,
+                                    "Damping": 20.0,
+                                    "Stiffness": 100.0
+                                },
+                                "Positive Limit": 360.0,
+                                "Negative Limit": -360.0
+                            },
+                            "Motor": {
+                                "UseMotor": false,
+                                "ForceLimit": 1.0
+                            },
+                            "Component Mode": {}
+                        }
+                    }
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1237305411567]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "value": 1
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1237305411567]/Components/ROS2FrameComponent/m_template/Publish Transform",
+                    "value": false
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[1237305411567]/Components/EditorHingeJointComponent"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[1237305411567]/Components/EditorRigidBodyComponent"
+                },
+                {
+                    "op": "add",
+                    "path": "/Entities/Entity_[1168585934831]/Components/EditorArticulationLinkComponent",
+                    "value": {
+                        "$type": "EditorArticulationLinkComponent",
+                        "Id": 18310815693205975203,
+                        "ArticulationConfiguration": {
+                            "name": "",
+                            "position": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "orientation": [
+                                0.0,
+                                0.0,
+                                0.0,
+                                1.0
+                            ],
+                            "entityId": "",
+                            "startSimulationEnabled": true,
+                            "Fixed Base": false,
+                            "Self Collide": false,
+                            "Mass": 1.0,
+                            "Gravity Enabled": true,
+                            "Linear damping": 0.05000000074505806,
+                            "Angular damping": 0.15000000596046448,
+                            "Sleep threshold": 0.004999999888241291,
+                            "Start Asleep": false,
+                            "Centre of mass offset": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Maximum Angular Velocity": 100.0,
+                            "SolverPositionIterations": 4,
+                            "SolverVelocityIterations": 1,
+                            "Articulation Joint Type": 1,
+                            "Local Position": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Local Rotation": [
+                                0.0,
+                                -90.0,
+                                0.0
+                            ],
+                            "Fix Joint Location": false,
+                            "Auto-calculate Lead frame": true,
+                            "Lead Local Position": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Lead Local Rotation": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Display Joint Setup": 1,
+                            "Is Limited": true,
+                            "Linear Limit Lower": -1.0,
+                            "Linear Limit Upper": 1.0,
+                            "Angular Limit Negative": 360.0,
+                            "Angular Limit Positive": -360.0,
+                            "Motor configuration": {
+                                "UseMotor": true,
+                                "ForceLimit": 1000.0,
+                                "Stiffness": 2000.0,
+                                "Damping": 300.0
+                            },
+                            "Armature": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Friction": 0.0,
+                            "Sensor Configurations": []
+                        }
+                    }
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1168585934831]/Components/EditorDisabledCompositionComponent/DisabledComponents",
+                    "value": {
+                        "EditorRigidBodyComponent": {
+                            "$type": "EditorRigidBodyComponent",
+                            "Id": 2487664085652031084,
+                            "Configuration": {
+                                "name": "",
+                                "position": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "orientation": [
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    1.0
+                                ],
+                                "entityId": "",
+                                "startSimulationEnabled": true,
+                                "Kinematic": false,
+                                "Initial linear velocity": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Initial angular velocity": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Linear damping": 0.05000000074505806,
+                                "Angular damping": 0.15000000596046448,
+                                "Sleep threshold": 0.004999999888241291,
+                                "Start Asleep": false,
+                                "Interpolate Motion": false,
+                                "Gravity Enabled": true,
+                                "CCD Enabled": false,
+                                "Compute Mass": false,
+                                "Lock Linear X": false,
+                                "Lock Linear Y": false,
+                                "Lock Linear Z": false,
+                                "Lock Angular X": false,
+                                "Lock Angular Y": false,
+                                "Lock Angular Z": false,
+                                "Mass": 1.218999981880188,
+                                "Compute COM": false,
+                                "Centre of mass offset": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Compute inertia": false,
+                                "Inertia tensor": [
+                                    0.0018310388550162315,
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    0.0018310388550162315,
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    0.0021941999439150095
+                                ],
+                                "Maximum Angular Velocity": 100.0,
+                                "Include All Shapes In Mass": false,
+                                "CCD Min Advance": 0.15000000596046448,
+                                "CCD Friction": false,
+                                "Open PhysX Configuration": false,
+                                "Debug Draw Center of Mass": false
+                            },
+                            "PhysXSpecificConfiguration": {
+                                "SolverPositionIterations": 40,
+                                "SolverVelocityIterations": 10
+                            }
+                        }
+                    }
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1168585934831]/Components/EditorPendingCompositionComponent/PendingComponents",
+                    "value": {
+                        "EditorHingeJointComponent": {
+                            "$type": "EditorHingeJointComponent",
+                            "Id": 4228821168727166008,
+                            "Configuration": {
+                                "Local Position": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Local Rotation": [
+                                    0.0,
+                                    -89.99999237060547,
+                                    0.0
+                                ],
+                                "Fix Joint Location": false,
+                                "Parent Entity": "Entity_[1237305411567]",
+                                "Child Entity": "Entity_[1168585934831]",
+                                "Breakable": false,
+                                "Maximum Force": 1.0,
+                                "Maximum Torque": 1.0,
+                                "Display Debug": 1,
+                                "Select Lead on Snap": true,
+                                "Self Collide": false
+                            },
+                            "Angular Limit": {
+                                "Standard Limit Configuration": {
+                                    "Name": "",
+                                    "Is Limited": true,
+                                    "Is Soft Limit": false,
+                                    "Tolerance": 0.10000000149011612,
+                                    "Damping": 20.0,
+                                    "Stiffness": 100.0
+                                },
+                                "Positive Limit": 360.0,
+                                "Negative Limit": -360.0
+                            },
+                            "Motor": {
+                                "UseMotor": false,
+                                "ForceLimit": 1.0
+                            },
+                            "Component Mode": {}
+                        }
+                    }
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1168585934831]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "value": 1
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1168585934831]/Components/ROS2FrameComponent/m_template/Publish Transform",
+                    "value": false
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[1168585934831]/Components/EditorHingeJointComponent"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[1168585934831]/Components/EditorRigidBodyComponent"
+                },
+                {
+                    "op": "add",
+                    "path": "/Entities/Entity_[1228715476975]/Components/EditorArticulationLinkComponent",
+                    "value": {
+                        "$type": "EditorArticulationLinkComponent",
+                        "Id": 15698341859360831512,
+                        "ArticulationConfiguration": {
+                            "name": "",
+                            "position": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "orientation": [
+                                0.0,
+                                0.0,
+                                0.0,
+                                1.0
+                            ],
+                            "entityId": "",
+                            "startSimulationEnabled": true,
+                            "Fixed Base": false,
+                            "Self Collide": false,
+                            "Mass": 1.0,
+                            "Gravity Enabled": true,
+                            "Linear damping": 0.05000000074505806,
+                            "Angular damping": 0.15000000596046448,
+                            "Sleep threshold": 0.004999999888241291,
+                            "Start Asleep": false,
+                            "Centre of mass offset": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Maximum Angular Velocity": 100.0,
+                            "SolverPositionIterations": 4,
+                            "SolverVelocityIterations": 1,
+                            "Articulation Joint Type": 1,
+                            "Local Position": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Local Rotation": [
+                                0.0,
+                                -90.0,
+                                0.0
+                            ],
+                            "Fix Joint Location": false,
+                            "Auto-calculate Lead frame": true,
+                            "Lead Local Position": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Lead Local Rotation": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Display Joint Setup": 1,
+                            "Is Limited": true,
+                            "Linear Limit Lower": -1.0,
+                            "Linear Limit Upper": 1.0,
+                            "Angular Limit Negative": 360.0,
+                            "Angular Limit Positive": -360.0,
+                            "Motor configuration": {
+                                "UseMotor": true,
+                                "ForceLimit": 1000.0,
+                                "Stiffness": 2000.0,
+                                "Damping": 300.0
+                            },
+                            "Armature": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Friction": 0.0,
+                            "Sensor Configurations": []
+                        }
+                    }
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1228715476975]/Components/EditorDisabledCompositionComponent/DisabledComponents",
+                    "value": {
+                        "EditorRigidBodyComponent": {
+                            "$type": "EditorRigidBodyComponent",
+                            "Id": 5624832871562135019,
+                            "Configuration": {
+                                "name": "",
+                                "position": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "orientation": [
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    1.0
+                                ],
+                                "entityId": "",
+                                "startSimulationEnabled": true,
+                                "Kinematic": false,
+                                "Initial linear velocity": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Initial angular velocity": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Linear damping": 0.05000000074505806,
+                                "Angular damping": 0.15000000596046448,
+                                "Sleep threshold": 0.004999999888241291,
+                                "Start Asleep": false,
+                                "Interpolate Motion": false,
+                                "Gravity Enabled": true,
+                                "CCD Enabled": false,
+                                "Compute Mass": false,
+                                "Lock Linear X": false,
+                                "Lock Linear Y": false,
+                                "Lock Linear Z": false,
+                                "Lock Angular X": false,
+                                "Lock Angular Y": false,
+                                "Lock Angular Z": false,
+                                "Mass": 0.18790000677108765,
+                                "Compute COM": false,
+                                "Centre of mass offset": [
+                                    0.0,
+                                    0.0,
+                                    -0.015250000171363354
+                                ],
+                                "Compute inertia": false,
+                                "Inertia tensor": [
+                                    0.00008062472625169903,
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    0.00008062472625169903,
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    0.00013211718760430813
+                                ],
+                                "Maximum Angular Velocity": 100.0,
+                                "Include All Shapes In Mass": false,
+                                "CCD Min Advance": 0.15000000596046448,
+                                "CCD Friction": false,
+                                "Open PhysX Configuration": false,
+                                "Debug Draw Center of Mass": false
+                            },
+                            "PhysXSpecificConfiguration": {
+                                "SolverPositionIterations": 40,
+                                "SolverVelocityIterations": 10
+                            }
+                        }
+                    }
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1228715476975]/Components/EditorPendingCompositionComponent/PendingComponents",
+                    "value": {
+                        "EditorHingeJointComponent": {
+                            "$type": "EditorHingeJointComponent",
+                            "Id": 16883181557595541209,
+                            "Configuration": {
+                                "Local Position": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Local Rotation": [
+                                    0.0,
+                                    -89.99999237060547,
+                                    0.0
+                                ],
+                                "Fix Joint Location": false,
+                                "Parent Entity": "Entity_[1168585934831]",
+                                "Child Entity": "Entity_[1228715476975]",
+                                "Breakable": false,
+                                "Maximum Force": 1.0,
+                                "Maximum Torque": 1.0,
+                                "Display Debug": 1,
+                                "Select Lead on Snap": true,
+                                "Self Collide": false
+                            },
+                            "Angular Limit": {
+                                "Standard Limit Configuration": {
+                                    "Name": "",
+                                    "Is Limited": true,
+                                    "Is Soft Limit": false,
+                                    "Tolerance": 0.10000000149011612,
+                                    "Damping": 20.0,
+                                    "Stiffness": 100.0
+                                },
+                                "Positive Limit": 360.0,
+                                "Negative Limit": -360.0
+                            },
+                            "Motor": {
+                                "UseMotor": false,
+                                "ForceLimit": 1.0
+                            },
+                            "Component Mode": {}
+                        }
+                    }
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1228715476975]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "value": 1
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1228715476975]/Components/ROS2FrameComponent/m_template/Publish Transform",
+                    "value": false
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[1228715476975]/Components/EditorHingeJointComponent"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[1228715476975]/Components/EditorRigidBodyComponent"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1185765804015]/Components/EditorPendingCompositionComponent/PendingComponents",
+                    "value": {
+                        "EditorFixedJointComponent": {
+                            "$type": "EditorFixedJointComponent",
+                            "Id": 2661907883375729967,
+                            "Configuration": {
+                                "Local Position": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Local Rotation": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Fix Joint Location": false,
+                                "Parent Entity": "",
+                                "Child Entity": "",
+                                "Breakable": false,
+                                "Maximum Force": 1.0,
+                                "Maximum Torque": 1.0,
+                                "Display Debug": 1,
+                                "Select Lead on Snap": true,
+                                "Self Collide": false
+                            },
+                            "Component Mode": {}
+                        }
+                    }
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1185765804015]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "value": 1
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1185765804015]/Components/ROS2FrameComponent/m_template/Publish Transform",
+                    "value": false
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[1185765804015]/Components/EditorFixedJointComponent"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1172880902127]/Components/EditorPendingCompositionComponent/PendingComponents",
+                    "value": {
+                        "EditorFixedJointComponent": {
+                            "$type": "EditorFixedJointComponent",
+                            "Id": 8265112374632981275,
+                            "Configuration": {
+                                "Local Position": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Local Rotation": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Fix Joint Location": false,
+                                "Parent Entity": "",
+                                "Child Entity": "",
+                                "Breakable": false,
+                                "Maximum Force": 1.0,
+                                "Maximum Torque": 1.0,
+                                "Display Debug": 1,
+                                "Select Lead on Snap": true,
+                                "Self Collide": false
+                            },
+                            "Component Mode": {}
+                        }
+                    }
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1172880902127]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "value": 1
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1172880902127]/Components/ROS2FrameComponent/m_template/Publish Transform",
+                    "value": false
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[1172880902127]/Components/EditorFixedJointComponent"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1164290967535]/Components/EditorPendingCompositionComponent/PendingComponents",
+                    "value": {
+                        "EditorFixedJointComponent": {
+                            "$type": "EditorFixedJointComponent",
+                            "Id": 7046635627295538536,
+                            "Configuration": {
+                                "Local Position": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Local Rotation": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Fix Joint Location": false,
+                                "Parent Entity": "",
+                                "Child Entity": "",
+                                "Breakable": false,
+                                "Maximum Force": 1.0,
+                                "Maximum Torque": 1.0,
+                                "Display Debug": 1,
+                                "Select Lead on Snap": true,
+                                "Self Collide": false
+                            },
+                            "Component Mode": {}
+                        }
+                    }
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1164290967535]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "value": 1
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1164290967535]/Components/ROS2FrameComponent/m_template/Publish Transform",
+                    "value": false
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[1164290967535]/Components/EditorFixedJointComponent"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1233010444271]/Components/EditorDisabledCompositionComponent/DisabledComponents",
+                    "value": {
+                        "ROS2RobotControlComponent": {
+                            "$type": "GenericComponentWrapper",
+                            "Id": 5958796147330969134,
+                            "m_template": {
+                                "$type": "ROS2RobotControlComponent",
+                                "Id": 0,
+                                "ControlConfiguration": {
+                                    "Steering": 0
+                                },
+                                "SubscriberConfiguration": {
+                                    "Type": "std_msgs::msg::Empty",
+                                    "Topic": "cmd_vel",
+                                    "QoS": {
+                                        "Reliability": 2,
+                                        "Durability": 2,
+                                        "Depth": 5
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1233010444271]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "value": 1
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[1233010444271]/Components/ROS2RobotControlComponent"
+                },
+                {
+                    "op": "add",
+                    "path": "/Entities/Entity_[1215830575087]/Components/EditorArticulationLinkComponent",
+                    "value": {
+                        "$type": "EditorArticulationLinkComponent",
+                        "Id": 4422926897063736124,
+                        "ArticulationConfiguration": {
+                            "name": "",
+                            "position": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "orientation": [
+                                0.0,
+                                0.0,
+                                0.0,
+                                1.0
+                            ],
+                            "entityId": "",
+                            "startSimulationEnabled": true,
+                            "Fixed Base": true,
+                            "Self Collide": false,
+                            "Mass": 1.0,
+                            "Gravity Enabled": true,
+                            "Linear damping": 0.05000000074505806,
+                            "Angular damping": 0.15000000596046448,
+                            "Sleep threshold": 0.004999999888241291,
+                            "Start Asleep": false,
+                            "Centre of mass offset": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Maximum Angular Velocity": 100.0,
+                            "SolverPositionIterations": 4,
+                            "SolverVelocityIterations": 1,
+                            "Articulation Joint Type": 0,
+                            "Local Position": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Local Rotation": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Fix Joint Location": false,
+                            "Auto-calculate Lead frame": true,
+                            "Lead Local Position": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Lead Local Rotation": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Display Joint Setup": 1,
+                            "Is Limited": true,
+                            "Linear Limit Lower": -1.0,
+                            "Linear Limit Upper": 1.0,
+                            "Angular Limit Negative": -45.0,
+                            "Angular Limit Positive": 45.0,
+                            "Motor configuration": {
+                                "UseMotor": false,
+                                "ForceLimit": 1.0,
+                                "Stiffness": 1.0,
+                                "Damping": 1.0
+                            },
+                            "Armature": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Friction": 0.0,
+                            "Sensor Configurations": []
+                        }
+                    }
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1215830575087]/Components/EditorPendingCompositionComponent/PendingComponents",
+                    "value": {
+                        "EditorFixedJointComponent": {
+                            "$type": "EditorFixedJointComponent",
+                            "Id": 2540807411163674559,
+                            "Configuration": {
+                                "Local Position": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Local Rotation": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Fix Joint Location": false,
+                                "Parent Entity": "",
+                                "Child Entity": "",
+                                "Breakable": false,
+                                "Maximum Force": 1.0,
+                                "Maximum Torque": 1.0,
+                                "Display Debug": 1,
+                                "Select Lead on Snap": true,
+                                "Self Collide": false
+                            },
+                            "Component Mode": {}
+                        }
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/Entities/Entity_[1215830575087]/Components/JointsArticulationControllerComponent",
+                    "value": {
+                        "$type": "GenericComponentWrapper",
+                        "Id": 10613034953263461176,
+                        "m_template": {
+                            "$type": "JointsArticulationControllerComponent",
+                            "Id": 0
+                        }
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/Entities/Entity_[1215830575087]/Components/JointsManipulationEditorComponent",
+                    "value": {
+                        "$type": "JointsManipulationEditorComponent",
+                        "Id": 11570448542158011578,
+                        "JointStatePublisherConfiguration": {
+                            "Publish": true,
+                            "Topic": {
+                                "Type": "sensor_msgs::msg::JointState",
+                                "Topic": "joint_states",
+                                "QoS": {
+                                    "Reliability": 1,
+                                    "Durability": 2,
+                                    "Depth": 5
+                                }
+                            },
+                            "Frequency": 25.0
+                        },
+                        "Initial positions": {
+                            "elbow_joint": -0.5,
+                            "shoulder_lift_joint": -1.5700000524520874,
+                            "shoulder_pan_joint": 0.0,
+                            "wrist_1_joint": 0.0,
+                            "wrist_2_joint": 0.0,
+                            "wrist_3_joint": 0.0
+                        }
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/Entities/Entity_[1215830575087]/Components/JointsTrajectoryComponent",
+                    "value": {
+                        "$type": "GenericComponentWrapper",
+                        "Id": 14232996109849348123,
+                        "m_template": {
+                            "$type": "JointsTrajectoryComponent",
+                            "Id": 0,
+                            "Action name": "joint_trajectory_controller/follow_joint_trajectory"
+                        }
+                    }
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1215830575087]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "value": 1
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[1215830575087]/Components/EditorFixedJointComponent"
+                },
+                {
+                    "op": "add",
+                    "path": "/Entities/Entity_[1190060771311]/Components/EditorArticulationLinkComponent",
+                    "value": {
+                        "$type": "EditorArticulationLinkComponent",
+                        "Id": 18058751888823389455,
+                        "ArticulationConfiguration": {
+                            "name": "",
+                            "position": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "orientation": [
+                                0.0,
+                                0.0,
+                                0.0,
+                                1.0
+                            ],
+                            "entityId": "",
+                            "startSimulationEnabled": true,
+                            "Fixed Base": false,
+                            "Self Collide": false,
+                            "Mass": 1.0,
+                            "Gravity Enabled": true,
+                            "Linear damping": 0.05000000074505806,
+                            "Angular damping": 0.15000000596046448,
+                            "Sleep threshold": 0.004999999888241291,
+                            "Start Asleep": false,
+                            "Centre of mass offset": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Maximum Angular Velocity": 100.0,
+                            "SolverPositionIterations": 4,
+                            "SolverVelocityIterations": 1,
+                            "Articulation Joint Type": 1,
+                            "Local Position": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Local Rotation": [
+                                0.0,
+                                -90.0,
+                                0.0
+                            ],
+                            "Fix Joint Location": false,
+                            "Auto-calculate Lead frame": true,
+                            "Lead Local Position": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Lead Local Rotation": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Display Joint Setup": 1,
+                            "Is Limited": true,
+                            "Linear Limit Lower": -1.0,
+                            "Linear Limit Upper": 1.0,
+                            "Angular Limit Negative": 360.0,
+                            "Angular Limit Positive": -360.0,
+                            "Motor configuration": {
+                                "UseMotor": true,
+                                "ForceLimit": 1000.0,
+                                "Stiffness": 2000.0,
+                                "Damping": 300.0
+                            },
+                            "Armature": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Friction": 0.0,
+                            "Sensor Configurations": []
+                        }
+                    }
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1190060771311]/Components/EditorDisabledCompositionComponent/DisabledComponents",
+                    "value": {
+                        "EditorRigidBodyComponent": {
+                            "$type": "EditorRigidBodyComponent",
+                            "Id": 13411689545511788138,
+                            "Configuration": {
+                                "name": "",
+                                "position": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "orientation": [
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    1.0
+                                ],
+                                "entityId": "",
+                                "startSimulationEnabled": true,
+                                "Kinematic": false,
+                                "Initial linear velocity": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Initial angular velocity": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Linear damping": 0.05000000074505806,
+                                "Angular damping": 0.15000000596046448,
+                                "Sleep threshold": 0.004999999888241291,
+                                "Start Asleep": false,
+                                "Interpolate Motion": false,
+                                "Gravity Enabled": true,
+                                "CCD Enabled": false,
+                                "Compute Mass": false,
+                                "Lock Linear X": false,
+                                "Lock Linear Y": false,
+                                "Lock Linear Z": false,
+                                "Lock Angular X": false,
+                                "Lock Angular Y": false,
+                                "Lock Angular Z": false,
+                                "Mass": 8.392999649047852,
+                                "Compute COM": false,
+                                "Centre of mass offset": [
+                                    -0.21250000596046448,
+                                    0.0,
+                                    0.13600000739097595
+                                ],
+                                "Compute inertia": false,
+                                "Inertia tensor": [
+                                    0.1338857859373093,
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    0.1338857859373093,
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    0.01510739978402853
+                                ],
+                                "Maximum Angular Velocity": 100.0,
+                                "Include All Shapes In Mass": false,
+                                "CCD Min Advance": 0.15000000596046448,
+                                "CCD Friction": false,
+                                "Open PhysX Configuration": false,
+                                "Debug Draw Center of Mass": false
+                            },
+                            "PhysXSpecificConfiguration": {
+                                "SolverPositionIterations": 40,
+                                "SolverVelocityIterations": 10
+                            }
+                        }
+                    }
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1190060771311]/Components/EditorPendingCompositionComponent/PendingComponents",
+                    "value": {
+                        "EditorHingeJointComponent": {
+                            "$type": "EditorHingeJointComponent",
+                            "Id": 3987400519655772359,
+                            "Configuration": {
+                                "Local Position": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Local Rotation": [
+                                    0.0,
+                                    -89.99999237060547,
+                                    0.0
+                                ],
+                                "Fix Joint Location": false,
+                                "Parent Entity": "Entity_[1224420509679]",
+                                "Child Entity": "Entity_[1190060771311]",
+                                "Breakable": false,
+                                "Maximum Force": 1.0,
+                                "Maximum Torque": 1.0,
+                                "Display Debug": 1,
+                                "Select Lead on Snap": true,
+                                "Self Collide": false
+                            },
+                            "Angular Limit": {
+                                "Standard Limit Configuration": {
+                                    "Name": "",
+                                    "Is Limited": true,
+                                    "Is Soft Limit": false,
+                                    "Tolerance": 0.10000000149011612,
+                                    "Damping": 20.0,
+                                    "Stiffness": 100.0
+                                },
+                                "Positive Limit": 360.0,
+                                "Negative Limit": -360.0
+                            },
+                            "Motor": {
+                                "UseMotor": false,
+                                "ForceLimit": 1.0
+                            },
+                            "Component Mode": {}
+                        }
+                    }
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1190060771311]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "value": 1
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1190060771311]/Components/ROS2FrameComponent/m_template/Publish Transform",
+                    "value": false
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[1190060771311]/Components/EditorHingeJointComponent"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[1190060771311]/Components/EditorRigidBodyComponent"
+                },
+                {
+                    "op": "add",
+                    "path": "/Entities/Entity_[1211535607791]/Components/EditorArticulationLinkComponent",
+                    "value": {
+                        "$type": "EditorArticulationLinkComponent",
+                        "Id": 5487282064059159540,
+                        "ArticulationConfiguration": {
+                            "name": "",
+                            "position": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "orientation": [
+                                0.0,
+                                0.0,
+                                0.0,
+                                1.0
+                            ],
+                            "entityId": "",
+                            "startSimulationEnabled": true,
+                            "Fixed Base": false,
+                            "Self Collide": false,
+                            "Mass": 1.0,
+                            "Gravity Enabled": true,
+                            "Linear damping": 0.05000000074505806,
+                            "Angular damping": 0.15000000596046448,
+                            "Sleep threshold": 0.004999999888241291,
+                            "Start Asleep": false,
+                            "Centre of mass offset": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Maximum Angular Velocity": 100.0,
+                            "SolverPositionIterations": 4,
+                            "SolverVelocityIterations": 1,
+                            "Articulation Joint Type": 1,
+                            "Local Position": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Local Rotation": [
+                                0.0,
+                                -90.0,
+                                0.0
+                            ],
+                            "Fix Joint Location": false,
+                            "Auto-calculate Lead frame": true,
+                            "Lead Local Position": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Lead Local Rotation": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Display Joint Setup": 1,
+                            "Is Limited": true,
+                            "Linear Limit Lower": -1.0,
+                            "Linear Limit Upper": 1.0,
+                            "Angular Limit Negative": 180.0,
+                            "Angular Limit Positive": -180.0,
+                            "Motor configuration": {
+                                "UseMotor": true,
+                                "ForceLimit": 1000.0,
+                                "Stiffness": 2000.0,
+                                "Damping": 300.0
+                            },
+                            "Armature": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Friction": 0.0,
+                            "Sensor Configurations": []
+                        }
+                    }
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1211535607791]/Components/EditorDisabledCompositionComponent/DisabledComponents",
+                    "value": {
+                        "EditorRigidBodyComponent": {
+                            "$type": "EditorRigidBodyComponent",
+                            "Id": 2516350535976444155,
+                            "Configuration": {
+                                "name": "",
+                                "position": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "orientation": [
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    1.0
+                                ],
+                                "entityId": "",
+                                "startSimulationEnabled": true,
+                                "Kinematic": false,
+                                "Initial linear velocity": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Initial angular velocity": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Linear damping": 0.05000000074505806,
+                                "Angular damping": 0.15000000596046448,
+                                "Sleep threshold": 0.004999999888241291,
+                                "Start Asleep": false,
+                                "Interpolate Motion": false,
+                                "Gravity Enabled": true,
+                                "CCD Enabled": false,
+                                "Compute Mass": false,
+                                "Lock Linear X": false,
+                                "Lock Linear Y": false,
+                                "Lock Linear Z": false,
+                                "Lock Angular X": false,
+                                "Lock Angular Y": false,
+                                "Lock Angular Z": false,
+                                "Mass": 2.2750000953674316,
+                                "Compute COM": false,
+                                "Centre of mass offset": [
+                                    -0.19612500071525577,
+                                    0.0,
+                                    0.016499999910593033
+                                ],
+                                "Compute inertia": false,
+                                "Inertia tensor": [
+                                    0.03121679089963436,
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    0.03121679089963436,
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    0.004095000214874744
+                                ],
+                                "Maximum Angular Velocity": 100.0,
+                                "Include All Shapes In Mass": false,
+                                "CCD Min Advance": 0.15000000596046448,
+                                "CCD Friction": false,
+                                "Open PhysX Configuration": false,
+                                "Debug Draw Center of Mass": false
+                            },
+                            "PhysXSpecificConfiguration": {
+                                "SolverPositionIterations": 40,
+                                "SolverVelocityIterations": 10
+                            }
+                        }
+                    }
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1211535607791]/Components/EditorPendingCompositionComponent/PendingComponents",
+                    "value": {
+                        "EditorHingeJointComponent": {
+                            "$type": "EditorHingeJointComponent",
+                            "Id": 15804288157601571380,
+                            "Configuration": {
+                                "Local Position": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Local Rotation": [
+                                    0.0,
+                                    -89.99999237060547,
+                                    0.0
+                                ],
+                                "Fix Joint Location": false,
+                                "Parent Entity": "Entity_[1190060771311]",
+                                "Child Entity": "Entity_[1211535607791]",
+                                "Breakable": false,
+                                "Maximum Force": 1.0,
+                                "Maximum Torque": 1.0,
+                                "Display Debug": 1,
+                                "Select Lead on Snap": true,
+                                "Self Collide": false
+                            },
+                            "Angular Limit": {
+                                "Standard Limit Configuration": {
+                                    "Name": "",
+                                    "Is Limited": true,
+                                    "Is Soft Limit": false,
+                                    "Tolerance": 0.10000000149011612,
+                                    "Damping": 20.0,
+                                    "Stiffness": 100.0
+                                },
+                                "Positive Limit": 180.0,
+                                "Negative Limit": -180.0
+                            },
+                            "Motor": {
+                                "UseMotor": false,
+                                "ForceLimit": 1.0
+                            },
+                            "Component Mode": {}
+                        }
+                    }
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1211535607791]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "value": 1
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1211535607791]/Components/ROS2FrameComponent/m_template/Publish Transform",
+                    "value": false
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[1211535607791]/Components/EditorHingeJointComponent"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[1211535607791]/Components/EditorRigidBodyComponent"
+                }
+            ]
+        }
+    }
+}

--- a/Levels/ur5_moveit/ur5_moveit.prefab
+++ b/Levels/ur5_moveit/ur5_moveit.prefab
@@ -20,7 +20,7 @@
                 "Id": 14126657869720434043,
                 "Child Entity Order": [
                     "Entity_[1176639161715]",
-                    "Instance_[1147111098351]/ContainerEntity",
+                    "Entity_[444059407894]",
                     "Entity_[1039454339336]"
                 ]
             },
@@ -562,2081 +562,1885 @@
                     "Id": 931091830724002070
                 }
             }
-        }
-    },
-    "Instances": {
-        "Instance_[1147111098351]": {
-            "Source": "Assets/Importer/urMoveit.prefab",
-            "Patches": [
-                {
-                    "op": "replace",
-                    "path": "/ContainerEntity/Components/TransformComponent/Parent Entity",
-                    "value": "../Entity_[1146574390643]"
+        },
+        "Entity_[444059407894]": {
+            "Id": "Entity_[444059407894]",
+            "Name": "urMoveit",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13401167008807306049
                 },
-                {
-                    "op": "replace",
-                    "path": "/ContainerEntity/Components/TransformComponent/Transform Data/Translate/2",
-                    "value": 0.23211252689361572
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 10912266591270684797
                 },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[1202945673199]/Components/EditorArticulationLinkComponent",
-                    "value": {
-                        "$type": "EditorArticulationLinkComponent",
-                        "Id": 18004175037883671043,
-                        "ArticulationConfiguration": {
-                            "name": "",
-                            "position": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "orientation": [
-                                0.0,
-                                0.0,
-                                0.0,
-                                1.0
-                            ],
-                            "entityId": "",
-                            "startSimulationEnabled": true,
-                            "Fixed Base": false,
-                            "Self Collide": false,
-                            "Mass": 1.0,
-                            "Gravity Enabled": true,
-                            "Linear damping": 0.05000000074505806,
-                            "Angular damping": 0.15000000596046448,
-                            "Sleep threshold": 0.004999999888241291,
-                            "Start Asleep": false,
-                            "Centre of mass offset": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Maximum Angular Velocity": 100.0,
-                            "SolverPositionIterations": 4,
-                            "SolverVelocityIterations": 1,
-                            "Articulation Joint Type": 0,
-                            "Local Position": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Local Rotation": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Fix Joint Location": false,
-                            "Auto-calculate Lead frame": true,
-                            "Lead Local Position": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Lead Local Rotation": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Display Joint Setup": 1,
-                            "Is Limited": true,
-                            "Linear Limit Lower": -1.0,
-                            "Linear Limit Upper": 1.0,
-                            "Angular Limit Negative": -45.0,
-                            "Angular Limit Positive": 45.0,
-                            "Motor configuration": {
-                                "UseMotor": false,
-                                "ForceLimit": 1.0,
-                                "Stiffness": 1.0,
-                                "Damping": 1.0
-                            },
-                            "Armature": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Friction": 0.0,
-                            "Sensor Configurations": []
-                        }
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 1928577071263824691,
+                    "Child Entity Order": [
+                        "Entity_[650217838102]"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 256821982620115944
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 18195379284223028734
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 9977448194352435575
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 9083105234093888756
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 14691164378096084501
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10202992886973601014,
+                    "Parent Entity": "Entity_[1146574390643]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.0,
+                            0.0,
+                            0.23211252689361572
+                        ]
                     }
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1202945673199]/Components/EditorDisabledCompositionComponent/DisabledComponents",
-                    "value": {
-                        "EditorRigidBodyComponent": {
-                            "$type": "EditorRigidBodyComponent",
-                            "Id": 11316019482129754262,
-                            "Configuration": {
-                                "name": "",
-                                "position": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "orientation": [
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    1.0
-                                ],
-                                "entityId": "",
-                                "startSimulationEnabled": true,
-                                "Kinematic": false,
-                                "Initial linear velocity": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Initial angular velocity": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Linear damping": 0.05000000074505806,
-                                "Angular damping": 0.15000000596046448,
-                                "Sleep threshold": 0.004999999888241291,
-                                "Start Asleep": false,
-                                "Interpolate Motion": false,
-                                "Gravity Enabled": true,
-                                "CCD Enabled": false,
-                                "Compute Mass": false,
-                                "Lock Linear X": false,
-                                "Lock Linear Y": false,
-                                "Lock Linear Z": false,
-                                "Lock Angular X": false,
-                                "Lock Angular Y": false,
-                                "Lock Angular Z": false,
-                                "Mass": 4.0,
-                                "Compute COM": false,
-                                "Centre of mass offset": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Compute inertia": false,
-                                "Inertia tensor": [
-                                    0.004433331545442343,
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    0.004433331545442343,
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    0.007200000341981649
-                                ],
-                                "Maximum Angular Velocity": 100.0,
-                                "Include All Shapes In Mass": false,
-                                "CCD Min Advance": 0.15000000596046448,
-                                "CCD Friction": false,
-                                "Open PhysX Configuration": false,
-                                "Debug Draw Center of Mass": false
-                            },
-                            "PhysXSpecificConfiguration": {
-                                "SolverPositionIterations": 40,
-                                "SolverVelocityIterations": 10
-                            }
-                        }
-                    }
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1202945673199]/Components/EditorPendingCompositionComponent/PendingComponents",
-                    "value": {
-                        "EditorFixedJointComponent": {
-                            "$type": "EditorFixedJointComponent",
-                            "Id": 2942888710629582036,
-                            "Configuration": {
-                                "Local Position": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Local Rotation": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Fix Joint Location": false,
-                                "Parent Entity": "Entity_[1215830575087]",
-                                "Child Entity": "Entity_[1202945673199]",
-                                "Breakable": false,
-                                "Maximum Force": 1.0,
-                                "Maximum Torque": 1.0,
-                                "Display Debug": 1,
-                                "Select Lead on Snap": true,
-                                "Self Collide": false
-                            },
-                            "Component Mode": {}
-                        }
-                    }
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1202945673199]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
-                    "value": 1
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1202945673199]/Components/ROS2FrameComponent/m_template/Publish Transform",
-                    "value": false
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[1202945673199]/Components/EditorFixedJointComponent"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[1202945673199]/Components/EditorRigidBodyComponent"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[1207240640495]/Components/EditorArticulationLinkComponent",
-                    "value": {
-                        "$type": "EditorArticulationLinkComponent",
-                        "Id": 176615949713617667,
-                        "ArticulationConfiguration": {
-                            "name": "",
-                            "position": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "orientation": [
-                                0.0,
-                                0.0,
-                                0.0,
-                                1.0
-                            ],
-                            "entityId": "",
-                            "startSimulationEnabled": true,
-                            "Fixed Base": false,
-                            "Self Collide": false,
-                            "Mass": 1.0,
-                            "Gravity Enabled": true,
-                            "Linear damping": 0.05000000074505806,
-                            "Angular damping": 0.15000000596046448,
-                            "Sleep threshold": 0.004999999888241291,
-                            "Start Asleep": false,
-                            "Centre of mass offset": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Maximum Angular Velocity": 100.0,
-                            "SolverPositionIterations": 4,
-                            "SolverVelocityIterations": 1,
-                            "Articulation Joint Type": 0,
-                            "Local Position": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Local Rotation": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Fix Joint Location": false,
-                            "Auto-calculate Lead frame": true,
-                            "Lead Local Position": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Lead Local Rotation": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Display Joint Setup": 1,
-                            "Is Limited": true,
-                            "Linear Limit Lower": -1.0,
-                            "Linear Limit Upper": 1.0,
-                            "Angular Limit Negative": -45.0,
-                            "Angular Limit Positive": 45.0,
-                            "Motor configuration": {
-                                "UseMotor": false,
-                                "ForceLimit": 1.0,
-                                "Stiffness": 1.0,
-                                "Damping": 1.0
-                            },
-                            "Armature": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Friction": 0.0,
-                            "Sensor Configurations": []
-                        }
-                    }
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1207240640495]/Components/EditorPendingCompositionComponent/PendingComponents",
-                    "value": {
-                        "EditorFixedJointComponent": {
-                            "$type": "EditorFixedJointComponent",
-                            "Id": 18274029838859631499,
-                            "Configuration": {
-                                "Local Position": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Local Rotation": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Fix Joint Location": false,
-                                "Parent Entity": "",
-                                "Child Entity": "",
-                                "Breakable": false,
-                                "Maximum Force": 1.0,
-                                "Maximum Torque": 1.0,
-                                "Display Debug": 1,
-                                "Select Lead on Snap": true,
-                                "Self Collide": false
-                            },
-                            "Component Mode": {}
-                        }
-                    }
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1207240640495]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
-                    "value": 1
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1207240640495]/Components/ROS2FrameComponent/m_template/Publish Transform",
-                    "value": false
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[1207240640495]/Components/EditorFixedJointComponent"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[1224420509679]/Components/EditorArticulationLinkComponent",
-                    "value": {
-                        "$type": "EditorArticulationLinkComponent",
-                        "Id": 8733688541086828833,
-                        "ArticulationConfiguration": {
-                            "name": "",
-                            "position": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "orientation": [
-                                0.0,
-                                0.0,
-                                0.0,
-                                1.0
-                            ],
-                            "entityId": "",
-                            "startSimulationEnabled": true,
-                            "Fixed Base": false,
-                            "Self Collide": false,
-                            "Mass": 1.0,
-                            "Gravity Enabled": true,
-                            "Linear damping": 0.05000000074505806,
-                            "Angular damping": 0.15000000596046448,
-                            "Sleep threshold": 0.004999999888241291,
-                            "Start Asleep": false,
-                            "Centre of mass offset": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Maximum Angular Velocity": 100.0,
-                            "SolverPositionIterations": 4,
-                            "SolverVelocityIterations": 1,
-                            "Articulation Joint Type": 1,
-                            "Local Position": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Local Rotation": [
-                                0.0,
-                                -90.0,
-                                0.0
-                            ],
-                            "Fix Joint Location": false,
-                            "Auto-calculate Lead frame": true,
-                            "Lead Local Position": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Lead Local Rotation": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Display Joint Setup": 1,
-                            "Is Limited": true,
-                            "Linear Limit Lower": -1.0,
-                            "Linear Limit Upper": 1.0,
-                            "Angular Limit Negative": 360.0,
-                            "Angular Limit Positive": -360.0,
-                            "Motor configuration": {
-                                "UseMotor": true,
-                                "ForceLimit": 1000.0,
-                                "Stiffness": 2000.0,
-                                "Damping": 300.0
-                            },
-                            "Armature": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Friction": 0.0,
-                            "Sensor Configurations": []
-                        }
-                    }
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1224420509679]/Components/EditorDisabledCompositionComponent/DisabledComponents",
-                    "value": {
-                        "EditorRigidBodyComponent": {
-                            "$type": "EditorRigidBodyComponent",
-                            "Id": 15972914335770594700,
-                            "Configuration": {
-                                "name": "",
-                                "position": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "orientation": [
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    1.0
-                                ],
-                                "entityId": "",
-                                "startSimulationEnabled": true,
-                                "Kinematic": false,
-                                "Initial linear velocity": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Initial angular velocity": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Linear damping": 0.05000000074505806,
-                                "Angular damping": 0.15000000596046448,
-                                "Sleep threshold": 0.004999999888241291,
-                                "Start Asleep": false,
-                                "Interpolate Motion": false,
-                                "Gravity Enabled": true,
-                                "CCD Enabled": false,
-                                "Compute Mass": false,
-                                "Lock Linear X": false,
-                                "Lock Linear Y": false,
-                                "Lock Linear Z": false,
-                                "Lock Angular X": false,
-                                "Lock Angular Y": false,
-                                "Lock Angular Z": false,
-                                "Mass": 3.700000047683716,
-                                "Compute COM": false,
-                                "Centre of mass offset": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Compute inertia": false,
-                                "Inertia tensor": [
-                                    0.014972352422773838,
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    0.014972352422773838,
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    0.01040625013411045
-                                ],
-                                "Maximum Angular Velocity": 100.0,
-                                "Include All Shapes In Mass": false,
-                                "CCD Min Advance": 0.15000000596046448,
-                                "CCD Friction": false,
-                                "Open PhysX Configuration": false,
-                                "Debug Draw Center of Mass": false
-                            },
-                            "PhysXSpecificConfiguration": {
-                                "SolverPositionIterations": 40,
-                                "SolverVelocityIterations": 10
-                            }
-                        }
-                    }
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1224420509679]/Components/EditorPendingCompositionComponent/PendingComponents",
-                    "value": {
-                        "EditorHingeJointComponent": {
-                            "$type": "EditorHingeJointComponent",
-                            "Id": 1643240907085891067,
-                            "Configuration": {
-                                "Local Position": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Local Rotation": [
-                                    0.0,
-                                    -89.99999237060547,
-                                    0.0
-                                ],
-                                "Fix Joint Location": false,
-                                "Parent Entity": "Entity_[1202945673199]",
-                                "Child Entity": "Entity_[1224420509679]",
-                                "Breakable": false,
-                                "Maximum Force": 1.0,
-                                "Maximum Torque": 1.0,
-                                "Display Debug": 1,
-                                "Select Lead on Snap": true,
-                                "Self Collide": false
-                            },
-                            "Angular Limit": {
-                                "Standard Limit Configuration": {
-                                    "Name": "",
-                                    "Is Limited": true,
-                                    "Is Soft Limit": false,
-                                    "Tolerance": 0.10000000149011612,
-                                    "Damping": 20.0,
-                                    "Stiffness": 100.0
-                                },
-                                "Positive Limit": 360.0,
-                                "Negative Limit": -360.0
-                            },
-                            "Motor": {
-                                "UseMotor": false,
-                                "ForceLimit": 1.0
-                            },
-                            "Component Mode": {}
-                        }
-                    }
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1224420509679]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
-                    "value": 1
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1224420509679]/Components/ROS2FrameComponent/m_template/Publish Transform",
-                    "value": false
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[1224420509679]/Components/EditorHingeJointComponent"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[1224420509679]/Components/EditorRigidBodyComponent"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[1237305411567]/Components/EditorArticulationLinkComponent",
-                    "value": {
-                        "$type": "EditorArticulationLinkComponent",
-                        "Id": 6603734076359607423,
-                        "ArticulationConfiguration": {
-                            "name": "",
-                            "position": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "orientation": [
-                                0.0,
-                                0.0,
-                                0.0,
-                                1.0
-                            ],
-                            "entityId": "",
-                            "startSimulationEnabled": true,
-                            "Fixed Base": false,
-                            "Self Collide": false,
-                            "Mass": 1.0,
-                            "Gravity Enabled": true,
-                            "Linear damping": 0.05000000074505806,
-                            "Angular damping": 0.15000000596046448,
-                            "Sleep threshold": 0.004999999888241291,
-                            "Start Asleep": false,
-                            "Centre of mass offset": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Maximum Angular Velocity": 100.0,
-                            "SolverPositionIterations": 4,
-                            "SolverVelocityIterations": 1,
-                            "Articulation Joint Type": 1,
-                            "Local Position": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Local Rotation": [
-                                0.0,
-                                -90.0,
-                                0.0
-                            ],
-                            "Fix Joint Location": false,
-                            "Auto-calculate Lead frame": true,
-                            "Lead Local Position": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Lead Local Rotation": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Display Joint Setup": 1,
-                            "Is Limited": true,
-                            "Linear Limit Lower": -1.0,
-                            "Linear Limit Upper": 1.0,
-                            "Angular Limit Negative": 360.0,
-                            "Angular Limit Positive": -360.0,
-                            "Motor configuration": {
-                                "UseMotor": true,
-                                "ForceLimit": 1000.0,
-                                "Stiffness": 2000.0,
-                                "Damping": 300.0
-                            },
-                            "Armature": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Friction": 0.0,
-                            "Sensor Configurations": []
-                        }
-                    }
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1237305411567]/Components/EditorDisabledCompositionComponent/DisabledComponents",
-                    "value": {
-                        "EditorRigidBodyComponent": {
-                            "$type": "EditorRigidBodyComponent",
-                            "Id": 9083091634387490518,
-                            "Configuration": {
-                                "name": "",
-                                "position": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "orientation": [
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    1.0
-                                ],
-                                "entityId": "",
-                                "startSimulationEnabled": true,
-                                "Kinematic": false,
-                                "Initial linear velocity": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Initial angular velocity": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Linear damping": 0.05000000074505806,
-                                "Angular damping": 0.15000000596046448,
-                                "Sleep threshold": 0.004999999888241291,
-                                "Start Asleep": false,
-                                "Interpolate Motion": false,
-                                "Gravity Enabled": true,
-                                "CCD Enabled": false,
-                                "Compute Mass": false,
-                                "Lock Linear X": false,
-                                "Lock Linear Y": false,
-                                "Lock Linear Z": false,
-                                "Lock Angular X": false,
-                                "Lock Angular Y": false,
-                                "Lock Angular Z": false,
-                                "Mass": 1.218999981880188,
-                                "Compute COM": false,
-                                "Centre of mass offset": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Compute inertia": false,
-                                "Inertia tensor": [
-                                    0.0020138886757194996,
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    0.0020138886757194996,
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    0.0021941999439150095
-                                ],
-                                "Maximum Angular Velocity": 100.0,
-                                "Include All Shapes In Mass": false,
-                                "CCD Min Advance": 0.15000000596046448,
-                                "CCD Friction": false,
-                                "Open PhysX Configuration": false,
-                                "Debug Draw Center of Mass": false
-                            },
-                            "PhysXSpecificConfiguration": {
-                                "SolverPositionIterations": 40,
-                                "SolverVelocityIterations": 10
-                            }
-                        }
-                    }
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1237305411567]/Components/EditorPendingCompositionComponent/PendingComponents",
-                    "value": {
-                        "EditorHingeJointComponent": {
-                            "$type": "EditorHingeJointComponent",
-                            "Id": 15082905903567508890,
-                            "Configuration": {
-                                "Local Position": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Local Rotation": [
-                                    0.0,
-                                    -89.99999237060547,
-                                    0.0
-                                ],
-                                "Fix Joint Location": false,
-                                "Parent Entity": "Entity_[1211535607791]",
-                                "Child Entity": "Entity_[1237305411567]",
-                                "Breakable": false,
-                                "Maximum Force": 1.0,
-                                "Maximum Torque": 1.0,
-                                "Display Debug": 1,
-                                "Select Lead on Snap": true,
-                                "Self Collide": false
-                            },
-                            "Angular Limit": {
-                                "Standard Limit Configuration": {
-                                    "Name": "",
-                                    "Is Limited": true,
-                                    "Is Soft Limit": false,
-                                    "Tolerance": 0.10000000149011612,
-                                    "Damping": 20.0,
-                                    "Stiffness": 100.0
-                                },
-                                "Positive Limit": 360.0,
-                                "Negative Limit": -360.0
-                            },
-                            "Motor": {
-                                "UseMotor": false,
-                                "ForceLimit": 1.0
-                            },
-                            "Component Mode": {}
-                        }
-                    }
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1237305411567]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
-                    "value": 1
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1237305411567]/Components/ROS2FrameComponent/m_template/Publish Transform",
-                    "value": false
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[1237305411567]/Components/EditorHingeJointComponent"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[1237305411567]/Components/EditorRigidBodyComponent"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[1168585934831]/Components/EditorArticulationLinkComponent",
-                    "value": {
-                        "$type": "EditorArticulationLinkComponent",
-                        "Id": 18310815693205975203,
-                        "ArticulationConfiguration": {
-                            "name": "",
-                            "position": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "orientation": [
-                                0.0,
-                                0.0,
-                                0.0,
-                                1.0
-                            ],
-                            "entityId": "",
-                            "startSimulationEnabled": true,
-                            "Fixed Base": false,
-                            "Self Collide": false,
-                            "Mass": 1.0,
-                            "Gravity Enabled": true,
-                            "Linear damping": 0.05000000074505806,
-                            "Angular damping": 0.15000000596046448,
-                            "Sleep threshold": 0.004999999888241291,
-                            "Start Asleep": false,
-                            "Centre of mass offset": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Maximum Angular Velocity": 100.0,
-                            "SolverPositionIterations": 4,
-                            "SolverVelocityIterations": 1,
-                            "Articulation Joint Type": 1,
-                            "Local Position": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Local Rotation": [
-                                0.0,
-                                -90.0,
-                                0.0
-                            ],
-                            "Fix Joint Location": false,
-                            "Auto-calculate Lead frame": true,
-                            "Lead Local Position": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Lead Local Rotation": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Display Joint Setup": 1,
-                            "Is Limited": true,
-                            "Linear Limit Lower": -1.0,
-                            "Linear Limit Upper": 1.0,
-                            "Angular Limit Negative": 360.0,
-                            "Angular Limit Positive": -360.0,
-                            "Motor configuration": {
-                                "UseMotor": true,
-                                "ForceLimit": 1000.0,
-                                "Stiffness": 2000.0,
-                                "Damping": 300.0
-                            },
-                            "Armature": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Friction": 0.0,
-                            "Sensor Configurations": []
-                        }
-                    }
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1168585934831]/Components/EditorDisabledCompositionComponent/DisabledComponents",
-                    "value": {
-                        "EditorRigidBodyComponent": {
-                            "$type": "EditorRigidBodyComponent",
-                            "Id": 2487664085652031084,
-                            "Configuration": {
-                                "name": "",
-                                "position": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "orientation": [
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    1.0
-                                ],
-                                "entityId": "",
-                                "startSimulationEnabled": true,
-                                "Kinematic": false,
-                                "Initial linear velocity": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Initial angular velocity": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Linear damping": 0.05000000074505806,
-                                "Angular damping": 0.15000000596046448,
-                                "Sleep threshold": 0.004999999888241291,
-                                "Start Asleep": false,
-                                "Interpolate Motion": false,
-                                "Gravity Enabled": true,
-                                "CCD Enabled": false,
-                                "Compute Mass": false,
-                                "Lock Linear X": false,
-                                "Lock Linear Y": false,
-                                "Lock Linear Z": false,
-                                "Lock Angular X": false,
-                                "Lock Angular Y": false,
-                                "Lock Angular Z": false,
-                                "Mass": 1.218999981880188,
-                                "Compute COM": false,
-                                "Centre of mass offset": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Compute inertia": false,
-                                "Inertia tensor": [
-                                    0.0018310388550162315,
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    0.0018310388550162315,
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    0.0021941999439150095
-                                ],
-                                "Maximum Angular Velocity": 100.0,
-                                "Include All Shapes In Mass": false,
-                                "CCD Min Advance": 0.15000000596046448,
-                                "CCD Friction": false,
-                                "Open PhysX Configuration": false,
-                                "Debug Draw Center of Mass": false
-                            },
-                            "PhysXSpecificConfiguration": {
-                                "SolverPositionIterations": 40,
-                                "SolverVelocityIterations": 10
-                            }
-                        }
-                    }
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1168585934831]/Components/EditorPendingCompositionComponent/PendingComponents",
-                    "value": {
-                        "EditorHingeJointComponent": {
-                            "$type": "EditorHingeJointComponent",
-                            "Id": 4228821168727166008,
-                            "Configuration": {
-                                "Local Position": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Local Rotation": [
-                                    0.0,
-                                    -89.99999237060547,
-                                    0.0
-                                ],
-                                "Fix Joint Location": false,
-                                "Parent Entity": "Entity_[1237305411567]",
-                                "Child Entity": "Entity_[1168585934831]",
-                                "Breakable": false,
-                                "Maximum Force": 1.0,
-                                "Maximum Torque": 1.0,
-                                "Display Debug": 1,
-                                "Select Lead on Snap": true,
-                                "Self Collide": false
-                            },
-                            "Angular Limit": {
-                                "Standard Limit Configuration": {
-                                    "Name": "",
-                                    "Is Limited": true,
-                                    "Is Soft Limit": false,
-                                    "Tolerance": 0.10000000149011612,
-                                    "Damping": 20.0,
-                                    "Stiffness": 100.0
-                                },
-                                "Positive Limit": 360.0,
-                                "Negative Limit": -360.0
-                            },
-                            "Motor": {
-                                "UseMotor": false,
-                                "ForceLimit": 1.0
-                            },
-                            "Component Mode": {}
-                        }
-                    }
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1168585934831]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
-                    "value": 1
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1168585934831]/Components/ROS2FrameComponent/m_template/Publish Transform",
-                    "value": false
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[1168585934831]/Components/EditorHingeJointComponent"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[1168585934831]/Components/EditorRigidBodyComponent"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[1228715476975]/Components/EditorArticulationLinkComponent",
-                    "value": {
-                        "$type": "EditorArticulationLinkComponent",
-                        "Id": 15698341859360831512,
-                        "ArticulationConfiguration": {
-                            "name": "",
-                            "position": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "orientation": [
-                                0.0,
-                                0.0,
-                                0.0,
-                                1.0
-                            ],
-                            "entityId": "",
-                            "startSimulationEnabled": true,
-                            "Fixed Base": false,
-                            "Self Collide": false,
-                            "Mass": 1.0,
-                            "Gravity Enabled": true,
-                            "Linear damping": 0.05000000074505806,
-                            "Angular damping": 0.15000000596046448,
-                            "Sleep threshold": 0.004999999888241291,
-                            "Start Asleep": false,
-                            "Centre of mass offset": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Maximum Angular Velocity": 100.0,
-                            "SolverPositionIterations": 4,
-                            "SolverVelocityIterations": 1,
-                            "Articulation Joint Type": 1,
-                            "Local Position": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Local Rotation": [
-                                0.0,
-                                -90.0,
-                                0.0
-                            ],
-                            "Fix Joint Location": false,
-                            "Auto-calculate Lead frame": true,
-                            "Lead Local Position": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Lead Local Rotation": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Display Joint Setup": 1,
-                            "Is Limited": true,
-                            "Linear Limit Lower": -1.0,
-                            "Linear Limit Upper": 1.0,
-                            "Angular Limit Negative": 360.0,
-                            "Angular Limit Positive": -360.0,
-                            "Motor configuration": {
-                                "UseMotor": true,
-                                "ForceLimit": 1000.0,
-                                "Stiffness": 2000.0,
-                                "Damping": 300.0
-                            },
-                            "Armature": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Friction": 0.0,
-                            "Sensor Configurations": []
-                        }
-                    }
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1228715476975]/Components/EditorDisabledCompositionComponent/DisabledComponents",
-                    "value": {
-                        "EditorRigidBodyComponent": {
-                            "$type": "EditorRigidBodyComponent",
-                            "Id": 5624832871562135019,
-                            "Configuration": {
-                                "name": "",
-                                "position": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "orientation": [
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    1.0
-                                ],
-                                "entityId": "",
-                                "startSimulationEnabled": true,
-                                "Kinematic": false,
-                                "Initial linear velocity": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Initial angular velocity": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Linear damping": 0.05000000074505806,
-                                "Angular damping": 0.15000000596046448,
-                                "Sleep threshold": 0.004999999888241291,
-                                "Start Asleep": false,
-                                "Interpolate Motion": false,
-                                "Gravity Enabled": true,
-                                "CCD Enabled": false,
-                                "Compute Mass": false,
-                                "Lock Linear X": false,
-                                "Lock Linear Y": false,
-                                "Lock Linear Z": false,
-                                "Lock Angular X": false,
-                                "Lock Angular Y": false,
-                                "Lock Angular Z": false,
-                                "Mass": 0.18790000677108765,
-                                "Compute COM": false,
-                                "Centre of mass offset": [
-                                    0.0,
-                                    0.0,
-                                    -0.015250000171363354
-                                ],
-                                "Compute inertia": false,
-                                "Inertia tensor": [
-                                    0.00008062472625169903,
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    0.00008062472625169903,
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    0.00013211718760430813
-                                ],
-                                "Maximum Angular Velocity": 100.0,
-                                "Include All Shapes In Mass": false,
-                                "CCD Min Advance": 0.15000000596046448,
-                                "CCD Friction": false,
-                                "Open PhysX Configuration": false,
-                                "Debug Draw Center of Mass": false
-                            },
-                            "PhysXSpecificConfiguration": {
-                                "SolverPositionIterations": 40,
-                                "SolverVelocityIterations": 10
-                            }
-                        }
-                    }
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1228715476975]/Components/EditorPendingCompositionComponent/PendingComponents",
-                    "value": {
-                        "EditorHingeJointComponent": {
-                            "$type": "EditorHingeJointComponent",
-                            "Id": 16883181557595541209,
-                            "Configuration": {
-                                "Local Position": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Local Rotation": [
-                                    0.0,
-                                    -89.99999237060547,
-                                    0.0
-                                ],
-                                "Fix Joint Location": false,
-                                "Parent Entity": "Entity_[1168585934831]",
-                                "Child Entity": "Entity_[1228715476975]",
-                                "Breakable": false,
-                                "Maximum Force": 1.0,
-                                "Maximum Torque": 1.0,
-                                "Display Debug": 1,
-                                "Select Lead on Snap": true,
-                                "Self Collide": false
-                            },
-                            "Angular Limit": {
-                                "Standard Limit Configuration": {
-                                    "Name": "",
-                                    "Is Limited": true,
-                                    "Is Soft Limit": false,
-                                    "Tolerance": 0.10000000149011612,
-                                    "Damping": 20.0,
-                                    "Stiffness": 100.0
-                                },
-                                "Positive Limit": 360.0,
-                                "Negative Limit": -360.0
-                            },
-                            "Motor": {
-                                "UseMotor": false,
-                                "ForceLimit": 1.0
-                            },
-                            "Component Mode": {}
-                        }
-                    }
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1228715476975]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
-                    "value": 1
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1228715476975]/Components/ROS2FrameComponent/m_template/Publish Transform",
-                    "value": false
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[1228715476975]/Components/EditorHingeJointComponent"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[1228715476975]/Components/EditorRigidBodyComponent"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1185765804015]/Components/EditorPendingCompositionComponent/PendingComponents",
-                    "value": {
-                        "EditorFixedJointComponent": {
-                            "$type": "EditorFixedJointComponent",
-                            "Id": 2661907883375729967,
-                            "Configuration": {
-                                "Local Position": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Local Rotation": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Fix Joint Location": false,
-                                "Parent Entity": "",
-                                "Child Entity": "",
-                                "Breakable": false,
-                                "Maximum Force": 1.0,
-                                "Maximum Torque": 1.0,
-                                "Display Debug": 1,
-                                "Select Lead on Snap": true,
-                                "Self Collide": false
-                            },
-                            "Component Mode": {}
-                        }
-                    }
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1185765804015]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
-                    "value": 1
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1185765804015]/Components/ROS2FrameComponent/m_template/Publish Transform",
-                    "value": false
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[1185765804015]/Components/EditorFixedJointComponent"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1172880902127]/Components/EditorPendingCompositionComponent/PendingComponents",
-                    "value": {
-                        "EditorFixedJointComponent": {
-                            "$type": "EditorFixedJointComponent",
-                            "Id": 8265112374632981275,
-                            "Configuration": {
-                                "Local Position": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Local Rotation": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Fix Joint Location": false,
-                                "Parent Entity": "",
-                                "Child Entity": "",
-                                "Breakable": false,
-                                "Maximum Force": 1.0,
-                                "Maximum Torque": 1.0,
-                                "Display Debug": 1,
-                                "Select Lead on Snap": true,
-                                "Self Collide": false
-                            },
-                            "Component Mode": {}
-                        }
-                    }
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1172880902127]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
-                    "value": 1
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1172880902127]/Components/ROS2FrameComponent/m_template/Publish Transform",
-                    "value": false
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[1172880902127]/Components/EditorFixedJointComponent"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1164290967535]/Components/EditorPendingCompositionComponent/PendingComponents",
-                    "value": {
-                        "EditorFixedJointComponent": {
-                            "$type": "EditorFixedJointComponent",
-                            "Id": 7046635627295538536,
-                            "Configuration": {
-                                "Local Position": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Local Rotation": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Fix Joint Location": false,
-                                "Parent Entity": "",
-                                "Child Entity": "",
-                                "Breakable": false,
-                                "Maximum Force": 1.0,
-                                "Maximum Torque": 1.0,
-                                "Display Debug": 1,
-                                "Select Lead on Snap": true,
-                                "Self Collide": false
-                            },
-                            "Component Mode": {}
-                        }
-                    }
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1164290967535]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
-                    "value": 1
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1164290967535]/Components/ROS2FrameComponent/m_template/Publish Transform",
-                    "value": false
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[1164290967535]/Components/EditorFixedJointComponent"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1233010444271]/Components/EditorDisabledCompositionComponent/DisabledComponents",
-                    "value": {
-                        "ROS2RobotControlComponent": {
-                            "$type": "GenericComponentWrapper",
-                            "Id": 5958796147330969134,
-                            "m_template": {
-                                "$type": "ROS2RobotControlComponent",
-                                "Id": 0,
-                                "ControlConfiguration": {
-                                    "Steering": 0
-                                },
-                                "SubscriberConfiguration": {
-                                    "Type": "std_msgs::msg::Empty",
-                                    "Topic": "cmd_vel",
-                                    "QoS": {
-                                        "Reliability": 2,
-                                        "Durability": 2,
-                                        "Depth": 5
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1233010444271]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
-                    "value": 1
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[1233010444271]/Components/ROS2RobotControlComponent"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[1215830575087]/Components/EditorArticulationLinkComponent",
-                    "value": {
-                        "$type": "EditorArticulationLinkComponent",
-                        "Id": 4422926897063736124,
-                        "ArticulationConfiguration": {
-                            "name": "",
-                            "position": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "orientation": [
-                                0.0,
-                                0.0,
-                                0.0,
-                                1.0
-                            ],
-                            "entityId": "",
-                            "startSimulationEnabled": true,
-                            "Fixed Base": true,
-                            "Self Collide": false,
-                            "Mass": 1.0,
-                            "Gravity Enabled": true,
-                            "Linear damping": 0.05000000074505806,
-                            "Angular damping": 0.15000000596046448,
-                            "Sleep threshold": 0.004999999888241291,
-                            "Start Asleep": false,
-                            "Centre of mass offset": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Maximum Angular Velocity": 100.0,
-                            "SolverPositionIterations": 4,
-                            "SolverVelocityIterations": 1,
-                            "Articulation Joint Type": 0,
-                            "Local Position": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Local Rotation": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Fix Joint Location": false,
-                            "Auto-calculate Lead frame": true,
-                            "Lead Local Position": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Lead Local Rotation": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Display Joint Setup": 1,
-                            "Is Limited": true,
-                            "Linear Limit Lower": -1.0,
-                            "Linear Limit Upper": 1.0,
-                            "Angular Limit Negative": -45.0,
-                            "Angular Limit Positive": 45.0,
-                            "Motor configuration": {
-                                "UseMotor": false,
-                                "ForceLimit": 1.0,
-                                "Stiffness": 1.0,
-                                "Damping": 1.0
-                            },
-                            "Armature": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Friction": 0.0,
-                            "Sensor Configurations": []
-                        }
-                    }
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1215830575087]/Components/EditorPendingCompositionComponent/PendingComponents",
-                    "value": {
-                        "EditorFixedJointComponent": {
-                            "$type": "EditorFixedJointComponent",
-                            "Id": 2540807411163674559,
-                            "Configuration": {
-                                "Local Position": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Local Rotation": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Fix Joint Location": false,
-                                "Parent Entity": "",
-                                "Child Entity": "",
-                                "Breakable": false,
-                                "Maximum Force": 1.0,
-                                "Maximum Torque": 1.0,
-                                "Display Debug": 1,
-                                "Select Lead on Snap": true,
-                                "Self Collide": false
-                            },
-                            "Component Mode": {}
-                        }
-                    }
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[1215830575087]/Components/JointsArticulationControllerComponent",
-                    "value": {
-                        "$type": "GenericComponentWrapper",
-                        "Id": 10613034953263461176,
-                        "m_template": {
-                            "$type": "JointsArticulationControllerComponent",
-                            "Id": 0
-                        }
-                    }
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[1215830575087]/Components/JointsManipulationEditorComponent",
-                    "value": {
-                        "$type": "JointsManipulationEditorComponent",
-                        "Id": 11570448542158011578,
-                        "JointStatePublisherConfiguration": {
-                            "Publish": true,
-                            "Topic": {
-                                "Type": "sensor_msgs::msg::JointState",
-                                "Topic": "joint_states",
-                                "QoS": {
-                                    "Reliability": 1,
-                                    "Durability": 2,
-                                    "Depth": 5
-                                }
-                            },
-                            "Frequency": 25.0
-                        },
-                        "Initial positions": {
-                            "elbow_joint": -0.5,
-                            "shoulder_lift_joint": -1.5700000524520874,
-                            "shoulder_pan_joint": 0.0,
-                            "wrist_1_joint": 0.0,
-                            "wrist_2_joint": 0.0,
-                            "wrist_3_joint": 0.0
-                        }
-                    }
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[1215830575087]/Components/JointsTrajectoryComponent",
-                    "value": {
-                        "$type": "GenericComponentWrapper",
-                        "Id": 14232996109849348123,
-                        "m_template": {
-                            "$type": "JointsTrajectoryComponent",
-                            "Id": 0,
-                            "Action name": "joint_trajectory_controller/follow_joint_trajectory"
-                        }
-                    }
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1215830575087]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
-                    "value": 1
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[1215830575087]/Components/EditorFixedJointComponent"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[1190060771311]/Components/EditorArticulationLinkComponent",
-                    "value": {
-                        "$type": "EditorArticulationLinkComponent",
-                        "Id": 18058751888823389455,
-                        "ArticulationConfiguration": {
-                            "name": "",
-                            "position": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "orientation": [
-                                0.0,
-                                0.0,
-                                0.0,
-                                1.0
-                            ],
-                            "entityId": "",
-                            "startSimulationEnabled": true,
-                            "Fixed Base": false,
-                            "Self Collide": false,
-                            "Mass": 1.0,
-                            "Gravity Enabled": true,
-                            "Linear damping": 0.05000000074505806,
-                            "Angular damping": 0.15000000596046448,
-                            "Sleep threshold": 0.004999999888241291,
-                            "Start Asleep": false,
-                            "Centre of mass offset": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Maximum Angular Velocity": 100.0,
-                            "SolverPositionIterations": 4,
-                            "SolverVelocityIterations": 1,
-                            "Articulation Joint Type": 1,
-                            "Local Position": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Local Rotation": [
-                                0.0,
-                                -90.0,
-                                0.0
-                            ],
-                            "Fix Joint Location": false,
-                            "Auto-calculate Lead frame": true,
-                            "Lead Local Position": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Lead Local Rotation": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Display Joint Setup": 1,
-                            "Is Limited": true,
-                            "Linear Limit Lower": -1.0,
-                            "Linear Limit Upper": 1.0,
-                            "Angular Limit Negative": 360.0,
-                            "Angular Limit Positive": -360.0,
-                            "Motor configuration": {
-                                "UseMotor": true,
-                                "ForceLimit": 1000.0,
-                                "Stiffness": 2000.0,
-                                "Damping": 300.0
-                            },
-                            "Armature": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Friction": 0.0,
-                            "Sensor Configurations": []
-                        }
-                    }
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1190060771311]/Components/EditorDisabledCompositionComponent/DisabledComponents",
-                    "value": {
-                        "EditorRigidBodyComponent": {
-                            "$type": "EditorRigidBodyComponent",
-                            "Id": 13411689545511788138,
-                            "Configuration": {
-                                "name": "",
-                                "position": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "orientation": [
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    1.0
-                                ],
-                                "entityId": "",
-                                "startSimulationEnabled": true,
-                                "Kinematic": false,
-                                "Initial linear velocity": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Initial angular velocity": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Linear damping": 0.05000000074505806,
-                                "Angular damping": 0.15000000596046448,
-                                "Sleep threshold": 0.004999999888241291,
-                                "Start Asleep": false,
-                                "Interpolate Motion": false,
-                                "Gravity Enabled": true,
-                                "CCD Enabled": false,
-                                "Compute Mass": false,
-                                "Lock Linear X": false,
-                                "Lock Linear Y": false,
-                                "Lock Linear Z": false,
-                                "Lock Angular X": false,
-                                "Lock Angular Y": false,
-                                "Lock Angular Z": false,
-                                "Mass": 8.392999649047852,
-                                "Compute COM": false,
-                                "Centre of mass offset": [
-                                    -0.21250000596046448,
-                                    0.0,
-                                    0.13600000739097595
-                                ],
-                                "Compute inertia": false,
-                                "Inertia tensor": [
-                                    0.1338857859373093,
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    0.1338857859373093,
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    0.01510739978402853
-                                ],
-                                "Maximum Angular Velocity": 100.0,
-                                "Include All Shapes In Mass": false,
-                                "CCD Min Advance": 0.15000000596046448,
-                                "CCD Friction": false,
-                                "Open PhysX Configuration": false,
-                                "Debug Draw Center of Mass": false
-                            },
-                            "PhysXSpecificConfiguration": {
-                                "SolverPositionIterations": 40,
-                                "SolverVelocityIterations": 10
-                            }
-                        }
-                    }
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1190060771311]/Components/EditorPendingCompositionComponent/PendingComponents",
-                    "value": {
-                        "EditorHingeJointComponent": {
-                            "$type": "EditorHingeJointComponent",
-                            "Id": 3987400519655772359,
-                            "Configuration": {
-                                "Local Position": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Local Rotation": [
-                                    0.0,
-                                    -89.99999237060547,
-                                    0.0
-                                ],
-                                "Fix Joint Location": false,
-                                "Parent Entity": "Entity_[1224420509679]",
-                                "Child Entity": "Entity_[1190060771311]",
-                                "Breakable": false,
-                                "Maximum Force": 1.0,
-                                "Maximum Torque": 1.0,
-                                "Display Debug": 1,
-                                "Select Lead on Snap": true,
-                                "Self Collide": false
-                            },
-                            "Angular Limit": {
-                                "Standard Limit Configuration": {
-                                    "Name": "",
-                                    "Is Limited": true,
-                                    "Is Soft Limit": false,
-                                    "Tolerance": 0.10000000149011612,
-                                    "Damping": 20.0,
-                                    "Stiffness": 100.0
-                                },
-                                "Positive Limit": 360.0,
-                                "Negative Limit": -360.0
-                            },
-                            "Motor": {
-                                "UseMotor": false,
-                                "ForceLimit": 1.0
-                            },
-                            "Component Mode": {}
-                        }
-                    }
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1190060771311]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
-                    "value": 1
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1190060771311]/Components/ROS2FrameComponent/m_template/Publish Transform",
-                    "value": false
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[1190060771311]/Components/EditorHingeJointComponent"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[1190060771311]/Components/EditorRigidBodyComponent"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[1211535607791]/Components/EditorArticulationLinkComponent",
-                    "value": {
-                        "$type": "EditorArticulationLinkComponent",
-                        "Id": 5487282064059159540,
-                        "ArticulationConfiguration": {
-                            "name": "",
-                            "position": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "orientation": [
-                                0.0,
-                                0.0,
-                                0.0,
-                                1.0
-                            ],
-                            "entityId": "",
-                            "startSimulationEnabled": true,
-                            "Fixed Base": false,
-                            "Self Collide": false,
-                            "Mass": 1.0,
-                            "Gravity Enabled": true,
-                            "Linear damping": 0.05000000074505806,
-                            "Angular damping": 0.15000000596046448,
-                            "Sleep threshold": 0.004999999888241291,
-                            "Start Asleep": false,
-                            "Centre of mass offset": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Maximum Angular Velocity": 100.0,
-                            "SolverPositionIterations": 4,
-                            "SolverVelocityIterations": 1,
-                            "Articulation Joint Type": 1,
-                            "Local Position": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Local Rotation": [
-                                0.0,
-                                -90.0,
-                                0.0
-                            ],
-                            "Fix Joint Location": false,
-                            "Auto-calculate Lead frame": true,
-                            "Lead Local Position": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Lead Local Rotation": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Display Joint Setup": 1,
-                            "Is Limited": true,
-                            "Linear Limit Lower": -1.0,
-                            "Linear Limit Upper": 1.0,
-                            "Angular Limit Negative": 180.0,
-                            "Angular Limit Positive": -180.0,
-                            "Motor configuration": {
-                                "UseMotor": true,
-                                "ForceLimit": 1000.0,
-                                "Stiffness": 2000.0,
-                                "Damping": 300.0
-                            },
-                            "Armature": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "Friction": 0.0,
-                            "Sensor Configurations": []
-                        }
-                    }
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1211535607791]/Components/EditorDisabledCompositionComponent/DisabledComponents",
-                    "value": {
-                        "EditorRigidBodyComponent": {
-                            "$type": "EditorRigidBodyComponent",
-                            "Id": 2516350535976444155,
-                            "Configuration": {
-                                "name": "",
-                                "position": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "orientation": [
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    1.0
-                                ],
-                                "entityId": "",
-                                "startSimulationEnabled": true,
-                                "Kinematic": false,
-                                "Initial linear velocity": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Initial angular velocity": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Linear damping": 0.05000000074505806,
-                                "Angular damping": 0.15000000596046448,
-                                "Sleep threshold": 0.004999999888241291,
-                                "Start Asleep": false,
-                                "Interpolate Motion": false,
-                                "Gravity Enabled": true,
-                                "CCD Enabled": false,
-                                "Compute Mass": false,
-                                "Lock Linear X": false,
-                                "Lock Linear Y": false,
-                                "Lock Linear Z": false,
-                                "Lock Angular X": false,
-                                "Lock Angular Y": false,
-                                "Lock Angular Z": false,
-                                "Mass": 2.2750000953674316,
-                                "Compute COM": false,
-                                "Centre of mass offset": [
-                                    -0.19612500071525577,
-                                    0.0,
-                                    0.016499999910593033
-                                ],
-                                "Compute inertia": false,
-                                "Inertia tensor": [
-                                    0.03121679089963436,
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    0.03121679089963436,
-                                    0.0,
-                                    0.0,
-                                    0.0,
-                                    0.004095000214874744
-                                ],
-                                "Maximum Angular Velocity": 100.0,
-                                "Include All Shapes In Mass": false,
-                                "CCD Min Advance": 0.15000000596046448,
-                                "CCD Friction": false,
-                                "Open PhysX Configuration": false,
-                                "Debug Draw Center of Mass": false
-                            },
-                            "PhysXSpecificConfiguration": {
-                                "SolverPositionIterations": 40,
-                                "SolverVelocityIterations": 10
-                            }
-                        }
-                    }
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1211535607791]/Components/EditorPendingCompositionComponent/PendingComponents",
-                    "value": {
-                        "EditorHingeJointComponent": {
-                            "$type": "EditorHingeJointComponent",
-                            "Id": 15804288157601571380,
-                            "Configuration": {
-                                "Local Position": [
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ],
-                                "Local Rotation": [
-                                    0.0,
-                                    -89.99999237060547,
-                                    0.0
-                                ],
-                                "Fix Joint Location": false,
-                                "Parent Entity": "Entity_[1190060771311]",
-                                "Child Entity": "Entity_[1211535607791]",
-                                "Breakable": false,
-                                "Maximum Force": 1.0,
-                                "Maximum Torque": 1.0,
-                                "Display Debug": 1,
-                                "Select Lead on Snap": true,
-                                "Self Collide": false
-                            },
-                            "Angular Limit": {
-                                "Standard Limit Configuration": {
-                                    "Name": "",
-                                    "Is Limited": true,
-                                    "Is Soft Limit": false,
-                                    "Tolerance": 0.10000000149011612,
-                                    "Damping": 20.0,
-                                    "Stiffness": 100.0
-                                },
-                                "Positive Limit": 180.0,
-                                "Negative Limit": -180.0
-                            },
-                            "Motor": {
-                                "UseMotor": false,
-                                "ForceLimit": 1.0
-                            },
-                            "Component Mode": {}
-                        }
-                    }
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1211535607791]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
-                    "value": 1
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[1211535607791]/Components/ROS2FrameComponent/m_template/Publish Transform",
-                    "value": false
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[1211535607791]/Components/EditorHingeJointComponent"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[1211535607791]/Components/EditorRigidBodyComponent"
                 }
-            ]
+            }
+        },
+        "Entity_[637332936214]": {
+            "Id": "Entity_[637332936214]",
+            "Name": "forearm_link_visual",
+            "Components": {
+                "AZ::Render::EditorMeshComponent": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 9018726767728602351,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{61798F7A-4504-5FB3-BC48-10BC2D2A0058}",
+                                    "subId": 274532406
+                                },
+                                "assetHint": "assets/urdfimporter/783534404_ur.urdf/forearm.azmodel"
+                            }
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13606003545171020777
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 7764389262481001945
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 15598833243314752539
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 15474697857480499290
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2357668015215086102
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4613830291205216886
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 1552784901357575044
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 2494889844806244165
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10453551656793666449,
+                    "Parent Entity": "Entity_[706052412950]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.0,
+                            0.0,
+                            0.016499999910593033
+                        ],
+                        "Rotate": [
+                            90.0,
+                            -90.0,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[641627903510]": {
+            "Id": "Entity_[641627903510]",
+            "Name": "wrist_3_link",
+            "Components": {
+                "EditorArticulationLinkComponent": {
+                    "$type": "EditorArticulationLinkComponent",
+                    "Id": 15698341859360831512,
+                    "ArticulationConfiguration": {
+                        "entityId": "",
+                        "Articulation Joint Type": 1,
+                        "Local Rotation": [
+                            0.0,
+                            -90.0,
+                            0.0
+                        ],
+                        "Angular Limit Negative": 360.0,
+                        "Angular Limit Positive": -360.0,
+                        "Motor configuration": {
+                            "UseMotor": true,
+                            "ForceLimit": 1000.0,
+                            "Stiffness": 2000.0,
+                            "Damping": 300.0
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 453233964865915281
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 12351337672897447763
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 17507704831636304945,
+                    "Child Entity Order": [
+                        "Entity_[701757445654]",
+                        "Entity_[680282609174]",
+                        "Entity_[723232282134]"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13574068365038325125
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 9054359797261818210
+                },
+                "EditorMeshColliderComponent": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 10429166737180254797,
+                    "ColliderConfiguration": {
+                        "Position": [
+                            0.0,
+                            0.0,
+                            -0.08179999887943268
+                        ],
+                        "Rotation": [
+                            0.7071067690849304,
+                            0.0,
+                            0.0,
+                            0.7071067690849304
+                        ],
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "DefaultMaterial"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "PhysicsAsset": {
+                            "Asset": {
+                                "assetId": {
+                                    "guid": "{2825F82C-8267-5AFB-93C3-0173E7CD8B0E}",
+                                    "subId": 885361371
+                                },
+                                "assetHint": "assets/urdfimporter/783534404_ur.urdf/wrist3.pxmesh"
+                            },
+                            "Configuration": {
+                                "PhysicsAsset": {
+                                    "assetId": {
+                                        "guid": "{2825F82C-8267-5AFB-93C3-0173E7CD8B0E}",
+                                        "subId": 885361371
+                                    },
+                                    "loadBehavior": "QueueLoad",
+                                    "assetHint": "assets/urdfimporter/783534404_ur.urdf/wrist3.pxmesh"
+                                },
+                                "UseMaterialsFromAsset": false
+                            }
+                        }
+                    }
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 16240469739370387253
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 13002095070005706399
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 647752823523104838
+                },
+                "ROS2FrameComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 1787384002178001588,
+                    "m_template": {
+                        "$type": "ROS2FrameComponent",
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "wrist_3_link",
+                        "Joint Name": "wrist_3_joint",
+                        "Publish Transform": false
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 14966459619236809864,
+                    "Parent Entity": "Entity_[718937314838]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.0,
+                            0.08229997754096985,
+                            1.257285475730896e-8
+                        ],
+                        "Rotate": [
+                            -90.00001525878906,
+                            -1.3559519403108056e-28,
+                            3.791516178933426e-22
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[645922870806]": {
+            "Id": "Entity_[645922870806]",
+            "Name": "base",
+            "Components": {
+                "EditorArticulationLinkComponent": {
+                    "$type": "EditorArticulationLinkComponent",
+                    "Id": 176615949713617667,
+                    "ArticulationConfiguration": {
+                        "entityId": ""
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 14051053292040405881
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 13493396853904625509
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 13417734704769742812
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 5260637340715767945
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 1266982641498145683
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 6909065964025968662
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 12295804609010388912
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4268841553206194579
+                },
+                "ROS2FrameComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 17375545524784855690,
+                    "m_template": {
+                        "$type": "ROS2FrameComponent",
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "base",
+                        "Joint Name": "base_link-base_fixed_joint",
+                        "Publish Transform": false
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 2778748892599747362,
+                    "Parent Entity": "Entity_[684577576470]",
+                    "Transform Data": {
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[650217838102]": {
+            "Id": "Entity_[650217838102]",
+            "Name": "world",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17758815968857029180
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3103153820240095749
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16883111640110723514,
+                    "Child Entity Order": [
+                        "Entity_[684577576470]"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17412389210624330589
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 12591191088475009733
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 15546394054832892389
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 1541658404030856660
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13412679523387291706
+                },
+                "ROS2FrameComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 16687608679585982249,
+                    "m_template": {
+                        "$type": "ROS2FrameComponent",
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "world"
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15170193674491297571,
+                    "Parent Entity": "Entity_[444059407894]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.0,
+                            0.0,
+                            -2.9802322387695313e-8
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[654512805398]": {
+            "Id": "Entity_[654512805398]",
+            "Name": "wrist_1_link_visual",
+            "Components": {
+                "AZ::Render::EditorMeshComponent": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 5435841460942642258,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{0AADB8B5-BDAA-5845-985F-172184352826}",
+                                    "subId": 283376957
+                                },
+                                "assetHint": "assets/urdfimporter/783534404_ur.urdf/wrist1.azmodel"
+                            }
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 12502295652067234470
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 12567171959276140635
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 13909866522374758448
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 8806087152263638337
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 13556774301632968640
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2357044949983239856
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 3400093061036791327
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 18269154857932012113
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 2150584639897984520,
+                    "Parent Entity": "Entity_[658807772694]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.0,
+                            0.0,
+                            -0.09300000220537186
+                        ],
+                        "Rotate": [
+                            89.99999237060547,
+                            0.0,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[658807772694]": {
+            "Id": "Entity_[658807772694]",
+            "Name": "wrist_1_link",
+            "Components": {
+                "EditorArticulationLinkComponent": {
+                    "$type": "EditorArticulationLinkComponent",
+                    "Id": 6603734076359607423,
+                    "ArticulationConfiguration": {
+                        "entityId": "",
+                        "Articulation Joint Type": 1,
+                        "Local Rotation": [
+                            0.0,
+                            -90.0,
+                            0.0
+                        ],
+                        "Angular Limit Negative": 360.0,
+                        "Angular Limit Positive": -360.0,
+                        "Motor configuration": {
+                            "UseMotor": true,
+                            "ForceLimit": 1000.0,
+                            "Stiffness": 2000.0,
+                            "Damping": 300.0
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 6283366667922547963
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 13426584124442234573
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 13667070041296652271,
+                    "Child Entity Order": [
+                        "Entity_[654512805398]",
+                        "Entity_[718937314838]"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 15963514784644279854
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14032049497897982494
+                },
+                "EditorMeshColliderComponent": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 17962113835867845871,
+                    "ColliderConfiguration": {
+                        "Position": [
+                            0.0,
+                            0.0,
+                            -0.09300000220537186
+                        ],
+                        "Rotation": [
+                            0.7071067690849304,
+                            0.0,
+                            0.0,
+                            0.7071067690849304
+                        ],
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "DefaultMaterial"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "PhysicsAsset": {
+                            "Asset": {
+                                "assetId": {
+                                    "guid": "{BAAD9718-A664-5BEC-92B8-8B391C0C4DAD}",
+                                    "subId": 2541752930
+                                },
+                                "assetHint": "assets/urdfimporter/783534404_ur.urdf/wrist1.pxmesh"
+                            },
+                            "Configuration": {
+                                "PhysicsAsset": {
+                                    "assetId": {
+                                        "guid": "{BAAD9718-A664-5BEC-92B8-8B391C0C4DAD}",
+                                        "subId": 2541752930
+                                    },
+                                    "loadBehavior": "QueueLoad",
+                                    "assetHint": "assets/urdfimporter/783534404_ur.urdf/wrist1.pxmesh"
+                                },
+                                "UseMaterialsFromAsset": false
+                            }
+                        }
+                    }
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4376365511047474256
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 4974049491368840350
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 6605297830136240376
+                },
+                "ROS2FrameComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 16405482811185229955,
+                    "m_template": {
+                        "$type": "ROS2FrameComponent",
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "wrist_1_link",
+                        "Joint Name": "wrist_1_joint",
+                        "Publish Transform": false
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 2195527968709481362,
+                    "Parent Entity": "Entity_[706052412950]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.3922499418258667,
+                            -2.2351741790771484e-8,
+                            0.1091499924659729
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[663102739990]": {
+            "Id": "Entity_[663102739990]",
+            "Name": "shoulder_link",
+            "Components": {
+                "EditorArticulationLinkComponent": {
+                    "$type": "EditorArticulationLinkComponent",
+                    "Id": 8733688541086828833,
+                    "ArticulationConfiguration": {
+                        "entityId": "",
+                        "Articulation Joint Type": 1,
+                        "Local Rotation": [
+                            0.0,
+                            -90.0,
+                            0.0
+                        ],
+                        "Angular Limit Negative": 360.0,
+                        "Angular Limit Positive": -360.0,
+                        "Motor configuration": {
+                            "UseMotor": true,
+                            "ForceLimit": 1000.0,
+                            "Stiffness": 2000.0,
+                            "Damping": 300.0
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 6825910910262722001
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5640486391480513514
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 688801696365909734,
+                    "Child Entity Order": [
+                        "Entity_[688872543766]",
+                        "Entity_[675987641878]"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 16922237610155443047
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 4050385619548902488
+                },
+                "EditorMeshColliderComponent": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 13139834304023403792,
+                    "ColliderConfiguration": {
+                        "Rotation": [
+                            0.0,
+                            0.0,
+                            1.0,
+                            6.123234262925839e-17
+                        ],
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "DefaultMaterial"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "PhysicsAsset": {
+                            "Asset": {
+                                "assetId": {
+                                    "guid": "{2A2FBD34-A2D2-562C-B8C8-A5AA97F5BEAB}",
+                                    "subId": 1468337438
+                                },
+                                "assetHint": "assets/urdfimporter/783534404_ur.urdf/shoulder.pxmesh"
+                            },
+                            "Configuration": {
+                                "PhysicsAsset": {
+                                    "assetId": {
+                                        "guid": "{2A2FBD34-A2D2-562C-B8C8-A5AA97F5BEAB}",
+                                        "subId": 1468337438
+                                    },
+                                    "loadBehavior": "QueueLoad",
+                                    "assetHint": "assets/urdfimporter/783534404_ur.urdf/shoulder.pxmesh"
+                                },
+                                "UseMaterialsFromAsset": false
+                            }
+                        }
+                    }
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 3262191907414126292
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17804401019373081075
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 7883156835889995140
+                },
+                "ROS2FrameComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 18299435543689378797,
+                    "m_template": {
+                        "$type": "ROS2FrameComponent",
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "shoulder_link",
+                        "Joint Name": "shoulder_pan_joint",
+                        "Publish Transform": false
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11970611978368704933,
+                    "Parent Entity": "Entity_[714642347542]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.0,
+                            0.0,
+                            0.08915899693965912
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[667397707286]": {
+            "Id": "Entity_[667397707286]",
+            "Name": "base_link_inertia_visual",
+            "Components": {
+                "AZ::Render::EditorMeshComponent": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 3160578405473985669,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{501BBAEE-663A-5A82-B1FB-2FBF8F3F7110}",
+                                    "subId": 280297057
+                                },
+                                "assetHint": "assets/urdfimporter/783534404_ur.urdf/base.azmodel"
+                            }
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 3332433060282292592
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 9688661122154598627
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16752754898612745570
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 4081645116466393
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 10924230022216563448
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 12010511056632313253
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14114652638883248470
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 3402403668426314660
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 2144851322405332082,
+                    "Parent Entity": "Entity_[714642347542]",
+                    "Transform Data": {
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[675987641878]": {
+            "Id": "Entity_[675987641878]",
+            "Name": "upper_arm_link",
+            "Components": {
+                "EditorArticulationLinkComponent": {
+                    "$type": "EditorArticulationLinkComponent",
+                    "Id": 18058751888823389455,
+                    "ArticulationConfiguration": {
+                        "entityId": "",
+                        "Articulation Joint Type": 1,
+                        "Local Rotation": [
+                            0.0,
+                            -90.0,
+                            0.0
+                        ],
+                        "Angular Limit Negative": 360.0,
+                        "Angular Limit Positive": -360.0,
+                        "Motor configuration": {
+                            "UseMotor": true,
+                            "ForceLimit": 1000.0,
+                            "Stiffness": 2000.0,
+                            "Damping": 300.0
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 15721472470196073362
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 15609529035781087829
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 1027454743946023850,
+                    "Child Entity Order": [
+                        "Entity_[693167511062]",
+                        "Entity_[706052412950]"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 12585704030099341764
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 16227665108153586142
+                },
+                "EditorMeshColliderComponent": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 12892795265270443520,
+                    "ColliderConfiguration": {
+                        "Position": [
+                            0.0,
+                            0.0,
+                            0.1358499974012375
+                        ],
+                        "Rotation": [
+                            0.5,
+                            -0.5,
+                            -0.5,
+                            0.5
+                        ],
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "DefaultMaterial"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "PhysicsAsset": {
+                            "Asset": {
+                                "assetId": {
+                                    "guid": "{977CDA7F-B9BC-546B-9DED-4C8A07B9255F}",
+                                    "subId": 3662157329
+                                },
+                                "assetHint": "assets/urdfimporter/783534404_ur.urdf/upperarm.pxmesh"
+                            },
+                            "Configuration": {
+                                "PhysicsAsset": {
+                                    "assetId": {
+                                        "guid": "{977CDA7F-B9BC-546B-9DED-4C8A07B9255F}",
+                                        "subId": 3662157329
+                                    },
+                                    "loadBehavior": "QueueLoad",
+                                    "assetHint": "assets/urdfimporter/783534404_ur.urdf/upperarm.pxmesh"
+                                },
+                                "UseMaterialsFromAsset": false
+                            }
+                        }
+                    }
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 9660889048282513150
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14425183701703761385
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 1717663267053625784
+                },
+                "ROS2FrameComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 4773712240584269181,
+                    "m_template": {
+                        "$type": "ROS2FrameComponent",
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "upper_arm_link",
+                        "Joint Name": "shoulder_lift_joint",
+                        "Publish Transform": false
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6694108772245886530,
+                    "Parent Entity": "Entity_[663102739990]",
+                    "Transform Data": {
+                        "Rotate": [
+                            89.99998474121094,
+                            -7.0167078561561656e-15,
+                            3.7915164313689154e-22
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[680282609174]": {
+            "Id": "Entity_[680282609174]",
+            "Name": "flange",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 5487668032515463895
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 10657555192373799839
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2128839892510514014,
+                    "Child Entity Order": [
+                        "Entity_[710347380246]"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 12986072092989922372
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 324782338854942893
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4219138306619743263
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14307318628094693385
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9262917567651941944
+                },
+                "ROS2FrameComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 11452813133349082093,
+                    "m_template": {
+                        "$type": "ROS2FrameComponent",
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "flange",
+                        "Joint Name": "wrist_3-flange",
+                        "Publish Transform": false
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6396529541356482957,
+                    "Parent Entity": "Entity_[641627903510]",
+                    "Transform Data": {
+                        "Rotate": [
+                            -89.9999771118164,
+                            0.000001707547198748216,
+                            -90.00000762939453
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[684577576470]": {
+            "Id": "Entity_[684577576470]",
+            "Name": "base_link",
+            "Components": {
+                "EditorArticulationLinkComponent": {
+                    "$type": "EditorArticulationLinkComponent",
+                    "Id": 4422926897063736124,
+                    "ArticulationConfiguration": {
+                        "entityId": "",
+                        "Fixed Base": true
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 14254051845699478482
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 8878520421989388632
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 8797251851126414648,
+                    "Child Entity Order": [
+                        "Entity_[714642347542]",
+                        "Entity_[645922870806]"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13988655352961562201
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 10763432535897720747
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 7880666295085040262
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 18098854983186689422
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 7681322933007099903
+                },
+                "JointsArticulationControllerComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 10613034953263461176,
+                    "m_template": {
+                        "$type": "JointsArticulationControllerComponent"
+                    }
+                },
+                "JointsManipulationEditorComponent": {
+                    "$type": "JointsManipulationEditorComponent",
+                    "Id": 11570448542158011578,
+                    "JointStatePublisherConfiguration": {
+                        "Topic": {
+                            "QoS": {
+                                "Reliability": 1
+                            }
+                        }
+                    },
+                    "Initial positions": {
+                        "elbow_joint": -0.5,
+                        "shoulder_lift_joint": -1.5700000524520874,
+                        "shoulder_pan_joint": {},
+                        "wrist_1_joint": {},
+                        "wrist_2_joint": {},
+                        "wrist_3_joint": {}
+                    }
+                },
+                "JointsTrajectoryComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 14232996109849348123,
+                    "m_template": {
+                        "$type": "JointsTrajectoryComponent",
+                        "Action name": "joint_trajectory_controller/follow_joint_trajectory"
+                    }
+                },
+                "ROS2FrameComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 9570519104337436796,
+                    "m_template": {
+                        "$type": "ROS2FrameComponent",
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "base_link",
+                        "Joint Name": "base_joint"
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 14267296153299729953,
+                    "Parent Entity": "Entity_[650217838102]"
+                }
+            }
+        },
+        "Entity_[688872543766]": {
+            "Id": "Entity_[688872543766]",
+            "Name": "shoulder_link_visual",
+            "Components": {
+                "AZ::Render::EditorMeshComponent": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 15196015856070888726,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{30D64B4A-A307-5DE9-B53C-BFB80F1CD37C}",
+                                    "subId": 278609181
+                                },
+                                "assetHint": "assets/urdfimporter/783534404_ur.urdf/shoulder.azmodel"
+                            }
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 260405586597077418
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6006525291165616807
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9590072363551886360
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 6294473200560498155
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14627714239028699360
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 15400419738840705448
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11606562678003793631
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 12144823767700703445
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9497023756474894875,
+                    "Parent Entity": "Entity_[663102739990]",
+                    "Transform Data": {
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[693167511062]": {
+            "Id": "Entity_[693167511062]",
+            "Name": "upper_arm_link_visual",
+            "Components": {
+                "AZ::Render::EditorMeshComponent": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 2371594324366327478,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{7F63A70F-C620-52D5-B601-D7BE161B8273}",
+                                    "subId": 270772955
+                                },
+                                "assetHint": "assets/urdfimporter/783534404_ur.urdf/upperarm.azmodel"
+                            }
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9386229655167429798
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 15586867683959172372
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 1854306022434033683
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 8090257565750491237
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 9823336549455137192
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 17608697224599962675
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 4865147845890142736
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 6849516534498500587
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5069271604893115754,
+                    "Parent Entity": "Entity_[675987641878]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.0,
+                            0.0,
+                            0.1358499974012375
+                        ],
+                        "Rotate": [
+                            90.0,
+                            -90.0,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[697462478358]": {
+            "Id": "Entity_[697462478358]",
+            "Name": "wrist_2_link_visual",
+            "Components": {
+                "AZ::Render::EditorMeshComponent": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 11098521529429125383,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{034FE6AD-C9B4-5FD0-8BA6-9D7A2BBF5719}",
+                                    "subId": 283815047
+                                },
+                                "assetHint": "assets/urdfimporter/783534404_ur.urdf/wrist2.azmodel"
+                            }
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16872778830819676783
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 11423037910936679083
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 495537097350871562
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 12752307428971400844
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2412323094693626842
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 15019513350538767434
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 345986957434801607
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 6248196006010180966
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 7865275478626892876,
+                    "Parent Entity": "Entity_[718937314838]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.0,
+                            0.0,
+                            -0.0949999988079071
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[701757445654]": {
+            "Id": "Entity_[701757445654]",
+            "Name": "wrist_3_link_visual",
+            "Components": {
+                "AZ::Render::EditorMeshComponent": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 14460665036110572071,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{72B9A64F-89CC-5E4B-A1C7-F4B4BEFD932A}",
+                                    "subId": 284007441
+                                },
+                                "assetHint": "assets/urdfimporter/783534404_ur.urdf/wrist3.azmodel"
+                            }
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 11949808796179772996
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 4035546638758015383
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 15362935525354752564
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 3840261792979133191
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 11554521867020127350
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4530158562668287905
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11788942428252157186
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 670285659988210878
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5377617498098703144,
+                    "Parent Entity": "Entity_[641627903510]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.0,
+                            0.0,
+                            -0.08179999887943268
+                        ],
+                        "Rotate": [
+                            89.99999237060547,
+                            0.0,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[706052412950]": {
+            "Id": "Entity_[706052412950]",
+            "Name": "forearm_link",
+            "Components": {
+                "EditorArticulationLinkComponent": {
+                    "$type": "EditorArticulationLinkComponent",
+                    "Id": 5487282064059159540,
+                    "ArticulationConfiguration": {
+                        "entityId": "",
+                        "Articulation Joint Type": 1,
+                        "Local Rotation": [
+                            0.0,
+                            -90.0,
+                            0.0
+                        ],
+                        "Angular Limit Negative": 180.0,
+                        "Angular Limit Positive": -180.0,
+                        "Motor configuration": {
+                            "UseMotor": true,
+                            "ForceLimit": 1000.0,
+                            "Stiffness": 2000.0,
+                            "Damping": 300.0
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10398996226318864671
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 8190228862534546402
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 1868078455822786953,
+                    "Child Entity Order": [
+                        "Entity_[637332936214]",
+                        "Entity_[658807772694]"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 204298559682621574
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 11623586191560432220
+                },
+                "EditorMeshColliderComponent": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 3012880230076608879,
+                    "ColliderConfiguration": {
+                        "Position": [
+                            0.0,
+                            0.0,
+                            0.016499999910593033
+                        ],
+                        "Rotation": [
+                            0.5,
+                            -0.5,
+                            -0.5,
+                            0.5
+                        ],
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "DefaultMaterial"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "PhysicsAsset": {
+                            "Asset": {
+                                "assetId": {
+                                    "guid": "{91DF02AB-4A5A-534E-B9FE-63297EB983CA}",
+                                    "subId": 1488848390
+                                },
+                                "assetHint": "assets/urdfimporter/783534404_ur.urdf/forearm.pxmesh"
+                            },
+                            "Configuration": {
+                                "PhysicsAsset": {
+                                    "assetId": {
+                                        "guid": "{91DF02AB-4A5A-534E-B9FE-63297EB983CA}",
+                                        "subId": 1488848390
+                                    },
+                                    "loadBehavior": "QueueLoad",
+                                    "assetHint": "assets/urdfimporter/783534404_ur.urdf/forearm.pxmesh"
+                                },
+                                "UseMaterialsFromAsset": false
+                            }
+                        }
+                    }
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5864465957870259376
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7487096221790961974
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 6972841326910009327
+                },
+                "ROS2FrameComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 1598407247910721613,
+                    "m_template": {
+                        "$type": "ROS2FrameComponent",
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "forearm_link",
+                        "Joint Name": "elbow_joint",
+                        "Publish Transform": false
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 17085465699576292114,
+                    "Parent Entity": "Entity_[675987641878]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.42500001192092896,
+                            0.0,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.000006830188794992864,
+                            -9.039679602072037e-29,
+                            -1.5166065725475662e-21
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[710347380246]": {
+            "Id": "Entity_[710347380246]",
+            "Name": "tool0",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13413178575742643823
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 11255469048557461146
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 14258789409936656255
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 80174993496017673
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 11612827455517078107
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2344443374280246020
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17171151966305139016
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 8289410352839384870
+                },
+                "ROS2FrameComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 9068964610393013544,
+                    "m_template": {
+                        "$type": "ROS2FrameComponent",
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "tool0",
+                        "Joint Name": "flange-tool0",
+                        "Publish Transform": false
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9595406432288590372,
+                    "Parent Entity": "Entity_[680282609174]",
+                    "Transform Data": {
+                        "Rotate": [
+                            90.0,
+                            89.99996185302734,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[714642347542]": {
+            "Id": "Entity_[714642347542]",
+            "Name": "base_link_inertia",
+            "Components": {
+                "EditorArticulationLinkComponent": {
+                    "$type": "EditorArticulationLinkComponent",
+                    "Id": 18004175037883671043,
+                    "ArticulationConfiguration": {
+                        "entityId": ""
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13678366325942524724
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16406500841097867785
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 17240616251983536940,
+                    "Child Entity Order": [
+                        "Entity_[667397707286]",
+                        "Entity_[663102739990]"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 45078894716668374
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 8166298529451985119
+                },
+                "EditorMeshColliderComponent": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 13161828885770491237,
+                    "ColliderConfiguration": {
+                        "Rotation": [
+                            0.0,
+                            0.0,
+                            1.0,
+                            6.123234262925839e-17
+                        ],
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "DefaultMaterial"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "PhysicsAsset": {
+                            "Asset": {
+                                "assetId": {
+                                    "guid": "{785530F6-38A6-51AF-8C2A-8F6FA0771984}",
+                                    "subId": 2491934069
+                                },
+                                "assetHint": "assets/urdfimporter/783534404_ur.urdf/base.pxmesh"
+                            },
+                            "Configuration": {
+                                "PhysicsAsset": {
+                                    "assetId": {
+                                        "guid": "{785530F6-38A6-51AF-8C2A-8F6FA0771984}",
+                                        "subId": 2491934069
+                                    },
+                                    "loadBehavior": "QueueLoad",
+                                    "assetHint": "assets/urdfimporter/783534404_ur.urdf/base.pxmesh"
+                                },
+                                "UseMaterialsFromAsset": false
+                            }
+                        }
+                    }
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1033332258524760046
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 13046724823623780661
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 494700599786390215
+                },
+                "ROS2FrameComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 710689454373378545,
+                    "m_template": {
+                        "$type": "ROS2FrameComponent",
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "base_link_inertia",
+                        "Joint Name": "base_link-base_link_inertia",
+                        "Publish Transform": false
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 16967659122272607157,
+                    "Parent Entity": "Entity_[684577576470]",
+                    "Transform Data": {
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[718937314838]": {
+            "Id": "Entity_[718937314838]",
+            "Name": "wrist_2_link",
+            "Components": {
+                "EditorArticulationLinkComponent": {
+                    "$type": "EditorArticulationLinkComponent",
+                    "Id": 18310815693205975203,
+                    "ArticulationConfiguration": {
+                        "entityId": "",
+                        "Articulation Joint Type": 1,
+                        "Local Rotation": [
+                            0.0,
+                            -90.0,
+                            0.0
+                        ],
+                        "Angular Limit Negative": 360.0,
+                        "Angular Limit Positive": -360.0,
+                        "Motor configuration": {
+                            "UseMotor": true,
+                            "ForceLimit": 1000.0,
+                            "Stiffness": 2000.0,
+                            "Damping": 300.0
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17617519167387097473
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 15508321476371347544
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2299863204117196779,
+                    "Child Entity Order": [
+                        "Entity_[697462478358]",
+                        "Entity_[641627903510]"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 1245058919933504948
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 13913103442222746550
+                },
+                "EditorMeshColliderComponent": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 10681730984554024425,
+                    "ColliderConfiguration": {
+                        "Position": [
+                            0.0,
+                            0.0,
+                            -0.0949999988079071
+                        ],
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "DefaultMaterial"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "PhysicsAsset": {
+                            "Asset": {
+                                "assetId": {
+                                    "guid": "{71DF6B98-F6FB-5401-B72A-22D98F6CEAD5}",
+                                    "subId": 1158927482
+                                },
+                                "assetHint": "assets/urdfimporter/783534404_ur.urdf/wrist2.pxmesh"
+                            },
+                            "Configuration": {
+                                "PhysicsAsset": {
+                                    "assetId": {
+                                        "guid": "{71DF6B98-F6FB-5401-B72A-22D98F6CEAD5}",
+                                        "subId": 1158927482
+                                    },
+                                    "loadBehavior": "QueueLoad",
+                                    "assetHint": "assets/urdfimporter/783534404_ur.urdf/wrist2.pxmesh"
+                                },
+                                "UseMaterialsFromAsset": false
+                            }
+                        }
+                    }
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 7211263665978666777
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2495576720337268932
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 10523129334332039809
+                },
+                "ROS2FrameComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 592265520795240687,
+                    "m_template": {
+                        "$type": "ROS2FrameComponent",
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "wrist_2_link",
+                        "Joint Name": "wrist_2_joint",
+                        "Publish Transform": false
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 16780211405266599001,
+                    "Parent Entity": "Entity_[658807772694]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.0,
+                            -0.09465000033378601,
+                            -1.4901161193847656e-8
+                        ],
+                        "Rotate": [
+                            90.00000762939453,
+                            -1.5166065725475662e-21,
+                            -7.0167078561561656e-15
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[723232282134]": {
+            "Id": "Entity_[723232282134]",
+            "Name": "ft_frame",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 12086206113249903643
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 10415867052603094894
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 15121582150797679334
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11323502983263890553
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14684878311773828007
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 630863469334091193
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 3768930271661577407
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 6406929912495202224
+                },
+                "ROS2FrameComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 17066634957970331869,
+                    "m_template": {
+                        "$type": "ROS2FrameComponent",
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "ft_frame",
+                        "Joint Name": "wrist_3_link-ft_frame",
+                        "Publish Transform": false
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10362111338004628344,
+                    "Parent Entity": "Entity_[641627903510]",
+                    "Transform Data": {
+                        "Rotate": [
+                            -179.99996948242188,
+                            -6.392019448087837e-29,
+                            -3.1960067147783805e-29
+                        ]
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
I've added a ur5 robotic arm prefab and tested it with Moveit.

Steps to recreate:
1. Clone and build [Universal_Robots_ROS2_Driver](https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver)
2. Create a level and use the ```urMoveit.prefab``` or use the ```ur5e_moveit``` level
3. Run ```ros2 launch ur_moveit_config ur_moveit.launch.py ur_type:=ur5 launch_rviz:=true use_sim_time:=true use_fake_hardware:=true``` in the sourced workplace and start using moveit.

Example video:
https://github.com/o3de/o3de-physics-test-scene/assets/130671280/22428b5a-b85c-48a9-a17a-f978455fd496

